### PR TITLE
L2 NFTs owned by the account in L1

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -22,10 +22,11 @@ import "./ZNSController.sol";
 import "./Proxy.sol";
 import "./UpgradeableMaster.sol";
 import "./Storage.sol";
+import "./lib/NFTHelper.sol";
 
 /// @title ZkBNB main contract
 /// @author ZkBNB Team
-contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Receiver {
+contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Receiver, NFTHelper {
     using SafeMath for uint256;
     using SafeMathUInt128 for uint128;
     using SafeMathUInt32 for uint32;
@@ -296,6 +297,9 @@ contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpg
         // add into priority request queue
         addPriorityRequest(TxTypes.TxType.DepositNft, pubData);
 
+        // delete nft from account at L1
+        _removeAccountNft(msg.sender, _nftL1Address, nftIndex);
+
         emit DepositNft(accountNameHash, nftContentHash, _nftL1Address, _nftL1TokenId, collectionId);
     }
 
@@ -346,6 +350,9 @@ contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpg
                 op.nftContentHash,
                 _emptyExtraData
             ) {
+                // add nft to account at L1
+                _addAccountNft(op.toAddress, _factoryAddress, op.nftIndex);
+
                 emit WithdrawNft(op.fromAccountIndex, _factoryAddress, op.toAddress, op.nftIndex);
             } catch {
                 storePendingNFT(op);

--- a/contracts/lib/NFTHelper.sol
+++ b/contracts/lib/NFTHelper.sol
@@ -2,17 +2,29 @@
 pragma solidity ^0.7.6;
 pragma experimental ABIEncoderV2;
 
+/**
+ * @title NFTHelper
+ * @notice NFTHelper use to store and query account nfts.
+ */
 contract NFTHelper {
     struct AccountNft {
-        address nftAddress; // nft factory address
+        address nftAddress; // nft address
         uint256 nftIndex;  // nft index
     }
 
     /// @notice L2 NFTs owned by the account in L1, maybe can store the nfts from L1 in the future
-    /// @dev address => NFTFactory => nft index list => bool
+    /// @dev account address => nft address => nft index => bool
     mapping(address => mapping(address => mapping(uint256 => bool))) public accountNftsMap;
+    /// @dev account address => nft list
     mapping(address => AccountNft[]) public accountNfts;
 
+    /**
+   * @dev Add nft to a account.
+   *
+   * @param _account The account address at L1.
+   * @param _nftAddress NFT factory address.
+   * @param _nftIndex NFT index.
+   */
     function _addAccountNft(address _account, address _nftAddress, uint256 _nftIndex) internal {
         if (!accountNftsMap[_account][_nftAddress][_nftIndex]) {
             accountNfts[_account].push(AccountNft({ nftAddress: _nftAddress, nftIndex: _nftIndex }));
@@ -20,6 +32,13 @@ contract NFTHelper {
         }
     }
 
+    /**
+   * @dev Remove nft from a account.
+   *
+   * @param _account The account address at L1.
+   * @param _nftAddress NFT factory address.
+   * @param _nftIndex NFT index.
+   */
     function _removeAccountNft(address _account, address _nftAddress, uint256 _nftIndex) internal {
         for (uint256 i = 0; i < accountNfts[_account].length; i++) {
             if (accountNfts[_account][i].nftAddress == _nftAddress
@@ -32,6 +51,11 @@ contract NFTHelper {
         }
     }
 
+    /**
+   * @dev Query nft list by account.
+   *
+   * @param _account The account address at L1.
+   */
     function getAccountNfts(address _account) external view returns (AccountNft[] memory) {
         AccountNft[] memory nfts = new AccountNft[](accountNfts[_account].length);
         for (uint256 i = 0; i < accountNfts[_account].length; i++) {

--- a/contracts/lib/NFTHelper.sol
+++ b/contracts/lib/NFTHelper.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.7.6;
+pragma experimental ABIEncoderV2;
+
+contract NFTHelper {
+    struct AccountNft {
+        address nftAddress; // nft factory address
+        uint256 nftIndex;  // nft index
+    }
+
+    /// @notice L2 NFTs owned by the account in L1, maybe can store the nfts from L1 in the future
+    /// @dev address => NFTFactory => nft index list => bool
+    mapping(address => mapping(address => mapping(uint256 => bool))) public accountNftsMap;
+    mapping(address => AccountNft[]) public accountNfts;
+
+    function _addAccountNft(address _account, address _nftAddress, uint256 _nftIndex) internal {
+        if (!accountNftsMap[_account][_nftAddress][_nftIndex]) {
+            accountNfts[_account].push(AccountNft({ nftAddress: _nftAddress, nftIndex: _nftIndex }));
+            accountNftsMap[_account][_nftAddress][_nftIndex] = true;
+        }
+    }
+
+    function _removeAccountNft(address _account, address _nftAddress, uint256 _nftIndex) internal {
+        for (uint256 i = 0; i < accountNfts[_account].length; i++) {
+            if (accountNfts[_account][i].nftAddress == _nftAddress
+                && accountNfts[_account][i].nftIndex == _nftIndex) {
+                accountNfts[_account][i] = accountNfts[_account][accountNfts[_account].length - 1];
+                accountNfts[_account].pop();
+                delete accountNftsMap[_account][_nftAddress][_nftIndex];
+                break;
+            }
+        }
+    }
+
+    function getAccountNfts(address _account) external view returns (AccountNft[] memory) {
+        AccountNft[] memory nfts = new AccountNft[](accountNfts[_account].length);
+        for (uint256 i = 0; i < accountNfts[_account].length; i++) {
+            AccountNft memory accountNft = accountNfts[_account][i];
+            nfts[i] = AccountNft({ nftAddress: accountNft.nftAddress, nftIndex: accountNft.nftIndex });
+        }
+        return nfts;
+    }
+}

--- a/contracts/test-contracts/NFTHelperTest.sol
+++ b/contracts/test-contracts/NFTHelperTest.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.7.6;
+pragma experimental ABIEncoderV2;
+
+import "../lib/NFTHelper.sol";
+
+contract NFTHelperTest is NFTHelper {
+    constructor() {}
+
+    function addAccountNft(address _account, address _nftAddress, uint256 _nftIndex) external {
+        _addAccountNft(_account, _nftAddress, _nftIndex);
+    }
+
+    function removeAccountNft(address _account, address _nftAddress, uint256 _nftIndex) external {
+        _removeAccountNft(_account, _nftAddress, _nftIndex);
+    }
+}

--- a/test/nftHelper.test.js
+++ b/test/nftHelper.test.js
@@ -4,40 +4,74 @@ const { BigNumber } = require("ethers");
 
 // Start test block
 describe('NFTHelperTest', function () {
-  const account = '0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5'
-  const nftAddress = '0xe688b84b23f322a994A53dbF8E15FA82CDB71127'
-  const nftIndex = 1
+  const account1 = ethers.Wallet.createRandom().address
+  const account2 = ethers.Wallet.createRandom().address
+  const nftAddress1 = ethers.Wallet.createRandom().address
+  const nftAddress2 = ethers.Wallet.createRandom().address
   beforeEach(async function () {
     const NftHelperTest = await ethers.getContractFactory('NFTHelperTest');
     this.nftHelperTest = await NftHelperTest.deploy();
   })
 
   it('add nfts', async function () {
-    let nfts = await this.nftHelperTest.getAccountNfts(account)
-    expect(nfts.length).to.equal(0)
-    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
-    nfts = await this.nftHelperTest.getAccountNfts(account)
-    expect(nfts[0].nftAddress).to.equal(nftAddress)
-    expect(BigNumber.from(nfts[0].nftIndex).eq(nftIndex))
+    const nftsMap = new Map()
+    for (let i = 1; i <= 10; i ++) {
+      nftsMap.set(`${nftAddress1}-${i}`, {
+        nftAddress: nftAddress1,
+        nftIndex: i,
+      })
+    }
+    const nfts = nftsMap.values()
+    for (let item of nfts) {
+      await this.nftHelperTest.addAccountNft(account1, item.nftAddress, item.nftIndex)
+      // repeat add the same nft
+      await this.nftHelperTest.addAccountNft(account1, item.nftAddress, item.nftIndex)
+    }
+
+    await this.nftHelperTest.addAccountNft(account2, nftAddress1, 1)
+    await this.nftHelperTest.addAccountNft(account2, nftAddress2, 2)
+    const account2Nfts = await this.nftHelperTest.getAccountNfts(account2)
+    expect(account2Nfts.length).to.equal(2)
+
+    const account1Nfts = await this.nftHelperTest.getAccountNfts(account1)
+    expect(account1Nfts.length).to.equal(nftsMap.size)
+
+    account1Nfts.forEach((item) => {
+      expect(nftsMap.has(`${item.nftAddress}-${item.nftIndex}`)).to.true
+    })
   });
 
   it('remove nfts', async function () {
-    await this.nftHelperTest.removeAccountNft(account, nftAddress, nftIndex)
-    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
-    nfts = await this.nftHelperTest.getAccountNfts(account)
-    expect(nfts[0].nftAddress).to.equal(nftAddress)
-    expect(BigNumber.from(nfts[0].nftIndex).eq(nftIndex))
-    await this.nftHelperTest.removeAccountNft(account, nftAddress, nftIndex)
-    nfts = await this.nftHelperTest.getAccountNfts(account)
-    expect(nfts.length).to.equal(0)
+    for (let i = 1; i <= 10; i ++) {
+      await this.nftHelperTest.addAccountNft(account1, nftAddress1, i)
+    }
+    const removeIndex = Math.ceil(Math.random() * 10)
+    await this.nftHelperTest.removeAccountNft(account1, nftAddress1, removeIndex)
+
+    const account1Nfts = await this.nftHelperTest.getAccountNfts(account1)
+    const nftsMap = new Map()
+    account1Nfts.forEach((item) => {
+      nftsMap.set(`${nftAddress1}-${item.nftIndex}`, item)
+    })
+    for (let i = 1; i <= 10; i ++) {
+      if (i === removeIndex) {
+        expect(nftsMap.has(`${nftAddress1}-${i}`)).to.false
+      } else {
+        expect(nftsMap.has(`${nftAddress1}-${i}`)).to.true
+      }
+    }
   });
 
   it('get nfts', async function () {
-    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
-    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
-    const nfts = await this.nftHelperTest.getAccountNfts(account)
-    expect(nfts.length).to.equal(1)
-    expect(nfts[0].nftAddress).to.equal(nftAddress)
-    expect(BigNumber.from(nfts[0].nftIndex).eq(nftIndex))
+    const total = 10;
+    for (let i = 1; i <= total; i ++) {
+      await this.nftHelperTest.addAccountNft(account1, nftAddress1, i)
+    }
+    const nfts = await this.nftHelperTest.getAccountNfts(account1)
+    expect(nfts.length).to.equal(total)
+    nfts.forEach((item, i) => {
+      expect(item.nftAddress).to.equal(nftAddress1)
+      expect(item.nftIndex.toString()).to.equal((i + 1).toString())
+    })
   });
 });

--- a/test/nftHelper.test.js
+++ b/test/nftHelper.test.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai');
+const {ethers} = require("hardhat");
+const { BigNumber } = require("ethers");
+
+// Start test block
+describe('NFTHelperTest', function () {
+  const account = '0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5'
+  const nftAddress = '0xe688b84b23f322a994A53dbF8E15FA82CDB71127'
+  const nftIndex = 1
+  beforeEach(async function () {
+    const NftHelperTest = await ethers.getContractFactory('NFTHelperTest');
+    this.nftHelperTest = await NftHelperTest.deploy();
+  })
+
+  it('add nfts', async function () {
+    let nfts = await this.nftHelperTest.getAccountNfts(account)
+    expect(nfts.length).to.equal(0)
+    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
+    nfts = await this.nftHelperTest.getAccountNfts(account)
+    expect(nfts[0].nftAddress).to.equal(nftAddress)
+    expect(BigNumber.from(nfts[0].nftIndex).eq(nftIndex))
+  });
+
+  it('remove nfts', async function () {
+    await this.nftHelperTest.removeAccountNft(account, nftAddress, nftIndex)
+    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
+    nfts = await this.nftHelperTest.getAccountNfts(account)
+    expect(nfts[0].nftAddress).to.equal(nftAddress)
+    expect(BigNumber.from(nfts[0].nftIndex).eq(nftIndex))
+    await this.nftHelperTest.removeAccountNft(account, nftAddress, nftIndex)
+    nfts = await this.nftHelperTest.getAccountNfts(account)
+    expect(nfts.length).to.equal(0)
+  });
+
+  it('get nfts', async function () {
+    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
+    await this.nftHelperTest.addAccountNft(account, nftAddress, nftIndex)
+    const nfts = await this.nftHelperTest.getAccountNfts(account)
+    expect(nfts.length).to.equal(1)
+    expect(nfts[0].nftAddress).to.equal(nftAddress)
+    expect(BigNumber.from(nfts[0].nftIndex).eq(nftIndex))
+  });
+});


### PR DESCRIPTION
### Description
add NFTHelper library contract to store L2 nfts owned by account in L1
### Rationale
Save new nfts when withdrawal from L2 to L1
Remvoe nfts when deposit nft from L1 to L2

### Example


### Changes

Notable changes:
* add NFTHelper library contract
* add account nfts when withdrawal nft in ZKBNB.sol
* remove account nfts when deposit nft in ZKBNB.sol
* add test cases