### PR TITLE
refactor: pubdata optimization

### DIFF
--- a/contracts/AdditionalZkBNB.sol
+++ b/contracts/AdditionalZkBNB.sol
@@ -314,11 +314,9 @@ contract AdditionalZkBNB is Storage, Config, Events, ReentrancyGuard, IERC721Rec
         creatorTreasuryRate : 0,
         nftIndex : _nftIndex,
         collectionId : 0, // unknown
-        nftL1Address : address(0x0), // unknown
         accountNameHash : accountNameHash,
         creatorAccountNameHash : bytes32(0),
-        nftContentHash : bytes32(0x0), // unknown,
-        nftL1TokenId : 0 // unknown
+        nftContentHash : bytes32(0x0) // unknown,
         });
         bytes memory pubData = TxTypes.writeFullExitNftPubDataForPriorityQueue(_tx);
         addPriorityRequest(TxTypes.TxType.FullExitNft, pubData);
@@ -434,13 +432,13 @@ contract AdditionalZkBNB is Storage, Config, Events, ReentrancyGuard, IERC721Rec
         StoredBlockInfo memory _previousBlock,
         CommitBlockInfo memory _newBlockData
     ) internal view returns (bytes32) {
-        uint256[] memory pubData = Utils.bytesToUint256Arr(_newBlockData.publicData);
+        // uint256[] memory pubData = Utils.bytesToUint256Arr(_newBlockData.publicData);
         bytes32 converted = keccak256(abi.encodePacked(
                 uint256(_newBlockData.blockNumber), // block number
                 uint256(_newBlockData.timestamp), // time stamp
                 _previousBlock.stateRoot, // old state root
                 _newBlockData.newStateRoot, // new state root
-                pubData, // pub data
+                _newBlockData.publicData, // pub data
                 uint256(_newBlockData.publicDataOffsets.length) // on chain ops count
             ));
         return converted;
@@ -457,7 +455,7 @@ contract AdditionalZkBNB is Storage, Config, Events, ReentrancyGuard, IERC721Rec
     {
         bytes memory pubData = _newBlockData.publicData;
 
-        require(pubData.length % TX_SIZE == 0, "A");
+        require(pubData.length % TxTypes.PACKED_TX_PUBDATA_BYTES == 0, "A");
 
         uint64 uncommittedPriorityRequestsOffset = firstPriorityRequestId + totalCommittedPriorityRequests;
         priorityOperationsProcessed = 0;

--- a/contracts/Config.sol
+++ b/contracts/Config.sol
@@ -44,8 +44,6 @@ contract Config {
 
     uint32 public constant MAX_FUNGIBLE_ASSET_ID = (2 ** 32) - 2;
 
-    uint256 public constant TX_SIZE = 6 * 32;
-
     uint40 public constant MAX_NFT_INDEX = (2 ** 40) - 2;
 
 }

--- a/contracts/StablePriceOracle.sol
+++ b/contracts/StablePriceOracle.sol
@@ -37,7 +37,7 @@ contract StablePriceOracle is IPriceOracle, OwnableUpgradeable {
         uint256 basePrice;
         if (len >= 3 && len < 10) {
             basePrice = price1Letter;
-        } else if (len >= 10 && len < 20) {
+        } else if (len >= 10 && len < 15) {
             basePrice = price2Letter;
         } else {
             basePrice = price3Letter;

--- a/contracts/TxTypes.sol
+++ b/contracts/TxTypes.sol
@@ -33,12 +33,13 @@ library TxTypes {
     // operation type bytes
     uint8 internal constant TX_TYPE_BYTES = 1;
 
-    uint256 internal constant PACKED_TX_PUBDATA_BYTES = 6 * CHUNK_SIZE;
+    // 968 bits
+    uint256 internal constant PACKED_TX_PUBDATA_BYTES = 121;
 
     struct RegisterZNS {
         uint8 txType;
         uint32 accountIndex;
-        bytes32 accountName;
+        bytes20 accountName;
         bytes32 accountNameHash;
         bytes32 pubKeyX;
         bytes32 pubKeyY;
@@ -62,17 +63,13 @@ library TxTypes {
         uint256 offset = TX_TYPE_BYTES;
         // account index
         (offset, parsed.accountIndex) = Bytes.readUInt32(_data, offset);
-        // empty data
-        offset += 27;
         // account name
-        (offset, parsed.accountName) = Bytes.readBytes32(_data, offset);
+        (offset, parsed.accountName) = Bytes.readBytes20(_data, offset);
         // account name hash
         (offset, parsed.accountNameHash) = Bytes.readBytes32(_data, offset);
         // public key
         (offset, parsed.pubKeyX) = Bytes.readBytes32(_data, offset);
         (offset, parsed.pubKeyY) = Bytes.readBytes32(_data, offset);
-
-        offset += 32;
 
         require(offset == PACKED_TX_PUBDATA_BYTES, "N");
         return parsed;
@@ -115,12 +112,10 @@ library TxTypes {
         (offset, parsed.assetId) = Bytes.readUInt16(_data, offset);
         // state amount
         (offset, parsed.amount) = Bytes.readUInt128(_data, offset);
-        // empty data
-        offset += 9;
         // account name
         (offset, parsed.accountNameHash) = Bytes.readBytes32(_data, offset);
 
-        offset += 128;
+        offset += 66;
 
         require(offset == PACKED_TX_PUBDATA_BYTES, "N");
         return parsed;
@@ -135,11 +130,11 @@ library TxTypes {
         uint8 txType;
         uint32 accountIndex;
         uint40 nftIndex;
-        address nftL1Address;
+        // address nftL1Address;
         uint32 creatorAccountIndex;
         uint16 creatorTreasuryRate;
         bytes32 nftContentHash;
-        uint256 nftL1TokenId;
+        // uint256 nftL1TokenId;
         bytes32 accountNameHash;
         uint16 collectionId;
     }
@@ -152,11 +147,9 @@ library TxTypes {
             uint8(TxType.DepositNft),
             uint32(0),
             uint40(_tx.nftIndex),
-            _tx.nftL1Address, // token address
             _tx.creatorAccountIndex,
             _tx.creatorTreasuryRate,
             _tx.nftContentHash,
-            _tx.nftL1TokenId, // nft token id
             _tx.accountNameHash,
             _tx.collectionId// account name hash
         );
@@ -170,10 +163,6 @@ library TxTypes {
         (offset, parsed.accountIndex) = Bytes.readUInt32(_data, offset);
         // nft index
         (offset, parsed.nftIndex) = Bytes.readUInt40(_data, offset);
-        // nft l1 address
-        (offset, parsed.nftL1Address) = Bytes.readAddress(_data, offset);
-        // empty data
-        offset += 26;
         // creator account index
         (offset, parsed.creatorAccountIndex) = Bytes.readUInt32(_data, offset);
         // creator treasury rate
@@ -182,12 +171,10 @@ library TxTypes {
         (offset, parsed.collectionId) = Bytes.readUInt16(_data, offset);
         // nft content hash
         (offset, parsed.nftContentHash) = Bytes.readBytes32(_data, offset);
-        // nft l1 token id
-        (offset, parsed.nftL1TokenId) = Bytes.readUInt256(_data, offset);
         // account name
         (offset, parsed.accountNameHash) = Bytes.readBytes32(_data, offset);
 
-        offset += 32;
+        offset += 39;
 
         require(offset == PACKED_TX_PUBDATA_BYTES, "N");
         return parsed;
@@ -205,7 +192,6 @@ library TxTypes {
         address toAddress;
         uint16 assetId;
         uint128 assetAmount;
-        uint32 gasFeeAccountIndex;
         uint16 gasFeeAssetId;
         uint16 gasFeeAssetAmount;
     }
@@ -222,17 +208,13 @@ library TxTypes {
         (offset, parsed.toAddress) = Bytes.readAddress(_data, offset);
         // asset id
         (offset, parsed.assetId) = Bytes.readUInt16(_data, offset);
-        // empty data
-        offset += 13;
         // amount
         (offset, parsed.assetAmount) = Bytes.readUInt128(_data, offset);
-        // gas fee account index
-        (offset, parsed.gasFeeAccountIndex) = Bytes.readUInt32(_data, offset);
         // gas fee asset id
         (offset, parsed.gasFeeAssetId) = Bytes.readUInt16(_data, offset);
         // gas fee asset amount
         (offset, parsed.gasFeeAssetAmount) = Bytes.readUInt16(_data, offset);
-        offset += 128;
+        offset += 74;
 
         require(offset == PACKED_TX_PUBDATA_BYTES, "N");
         return parsed;
@@ -245,13 +227,13 @@ library TxTypes {
         uint32 creatorAccountIndex;
         uint16 creatorTreasuryRate;
         uint40 nftIndex;
-        address nftL1Address;
+        // address nftL1Address;
         address toAddress;
         uint32 gasFeeAccountIndex;
         uint16 gasFeeAssetId;
         uint16 gasFeeAssetAmount;
         bytes32 nftContentHash;
-        uint256 nftL1TokenId;
+        // uint256 nftL1TokenId;
         bytes32 creatorAccountNameHash;
         uint32 collectionId;
     }
@@ -272,27 +254,18 @@ library TxTypes {
         (offset, parsed.nftIndex) = Bytes.readUInt40(_data, offset);
         // collection id
         (offset, parsed.collectionId) = Bytes.readUInt16(_data, offset);
-        // empty data
-        offset += 26;
-        // nft l1 address
-        (offset, parsed.nftL1Address) = Bytes.readAddress(_data, offset);
-        // empty data
-        offset += 4;
         // nft l1 address
         (offset, parsed.toAddress) = Bytes.readAddress(_data, offset);
-        // gas fee account index
-        (offset, parsed.gasFeeAccountIndex) = Bytes.readUInt32(_data, offset);
         // gas fee asset id
         (offset, parsed.gasFeeAssetId) = Bytes.readUInt16(_data, offset);
         // gas fee asset amount
         (offset, parsed.gasFeeAssetAmount) = Bytes.readUInt16(_data, offset);
         // nft content hash
         (offset, parsed.nftContentHash) = Bytes.readBytes32(_data, offset);
-        // nft token id
-        (offset, parsed.nftL1TokenId) = Bytes.readUInt256(_data, offset);
         // account name hash
         (offset, parsed.creatorAccountNameHash) = Bytes.readBytes32(_data, offset);
 
+        offset += 15;
         require(offset == PACKED_TX_PUBDATA_BYTES, "N");
         return parsed;
     }
@@ -329,12 +302,10 @@ library TxTypes {
         (offset, parsed.assetId) = Bytes.readUInt16(_data, offset);
         // asset state amount
         (offset, parsed.assetAmount) = Bytes.readUInt128(_data, offset);
-        // empty data
-        offset += 9;
         // account name
         (offset, parsed.accountNameHash) = Bytes.readBytes32(_data, offset);
 
-        offset += 128;
+        offset += 66;
 
         require(offset == PACKED_TX_PUBDATA_BYTES, "N");
         return parsed;
@@ -353,11 +324,11 @@ library TxTypes {
         uint16 creatorTreasuryRate;
         uint40 nftIndex;
         uint16 collectionId;
-        address nftL1Address;
+        // address nftL1Address;
         bytes32 accountNameHash;
         bytes32 creatorAccountNameHash;
         bytes32 nftContentHash;
-        uint256 nftL1TokenId;
+        // uint256 nftL1TokenId;
     }
 
     //    uint256 internal constant PACKED_FULLEXITNFT_PUBDATA_BYTES = 6 * CHUNK_SIZE;
@@ -371,11 +342,9 @@ library TxTypes {
             uint16(0),
             _tx.nftIndex,
             uint16(0), // collection id
-            address(0x0), // nft l1 address
             _tx.accountNameHash, // account name hash
             bytes32(0), // creator account name hash
-            bytes32(0), // nft content hash
-            uint256(0) // token id
+            bytes32(0)  // nft content hash
         );
     }
 
@@ -393,19 +362,14 @@ library TxTypes {
         (offset, parsed.nftIndex) = Bytes.readUInt40(_data, offset);
         // collection id
         (offset, parsed.collectionId) = Bytes.readUInt16(_data, offset);
-        // empty data
-        offset += 26;
-        // nft l1 address
-        (offset, parsed.nftL1Address) = Bytes.readAddress(_data, offset);
         // account name hash
         (offset, parsed.accountNameHash) = Bytes.readBytes32(_data, offset);
         // creator account name hash
         (offset, parsed.creatorAccountNameHash) = Bytes.readBytes32(_data, offset);
         // nft content hash
         (offset, parsed.nftContentHash) = Bytes.readBytes32(_data, offset);
-        // nft l1 token id
-        (offset, parsed.nftL1TokenId) = Bytes.readUInt256(_data, offset);
 
+        offset += 7;
         require(offset == PACKED_TX_PUBDATA_BYTES, "N");
         return parsed;
     }

--- a/contracts/Utils.sol
+++ b/contracts/Utils.sol
@@ -129,7 +129,7 @@ library Utils {
         return ecrecover(_messageHash, signV, signR, signS);
     }
 
-    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
+    function stringToBytes20(string memory source) public pure returns (bytes20 result) {
         bytes memory tempEmptyStringTest = bytes(source);
         if (tempEmptyStringTest.length == 0) {
             return 0x0;

--- a/contracts/ZNSController.sol
+++ b/contracts/ZNSController.sol
@@ -163,7 +163,7 @@ contract ZNSController is IBaseRegistrar, OwnableUpgradeable, ReentrancyGuardUpg
     }
 
     function _validLength(string memory _name) internal pure returns (bool) {
-        return _name.strlen() >= 3 && _name.strlen() <= 32;
+        return _name.strlen() >= 3 && _name.strlen() <= 20;
     }
 
     function _validPubKey(bytes32 _pubKey) internal view returns (bool) {

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -179,7 +179,7 @@ contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpg
         TxTypes.RegisterZNS memory _tx = TxTypes.RegisterZNS({
         txType : uint8(TxTypes.TxType.RegisterZNS),
         accountIndex : accountIndex,
-        accountName : Utils.stringToBytes32(_name),
+        accountName : Utils.stringToBytes20(_name),
         accountNameHash : node,
         pubKeyX : _zkbnbPubKeyX,
         pubKeyY : _zkbnbPubKeyY
@@ -282,11 +282,9 @@ contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpg
             txType : uint8(TxTypes.TxType.DepositNft),
             accountIndex : 0, // unknown at this point
             nftIndex : nftIndex,
-            nftL1Address : _nftL1Address,
             creatorAccountIndex : creatorAccountIndex,
             creatorTreasuryRate : creatorTreasuryRate,
             nftContentHash : nftContentHash,
-            nftL1TokenId : _nftL1TokenId,
             accountNameHash : accountNameHash,
             collectionId : collectionId
         });
@@ -306,32 +304,28 @@ contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpg
     function withdrawOrStoreNFT(TxTypes.WithdrawNft memory op) internal {
         require(op.nftIndex <= MAX_NFT_INDEX, "invalid nft index");
 
+        // get nft factory
+        address _factoryAddress = address(getNFTFactory(op.creatorAccountNameHash, op.collectionId));
+        bytes32 nftKey = keccak256(abi.encode(_factoryAddress, op.nftIndex));
+        bool alreadyMintedFlag = false;
+        if (l2Nfts[nftKey].nftContentHash != bytes32(0)) {
+            alreadyMintedFlag = true;
+        }
         // get layer-1 address by account name hash
         bytes memory _emptyExtraData;
-        if (op.nftL1Address != address(0x00)) {
+        if (alreadyMintedFlag) {
             /// This is a NFT from layer 1, withdraw id directly
-            try IERC721(op.nftL1Address).safeTransferFrom{gas : WITHDRAWAL_NFT_GAS_LIMIT}(
+            try IERC721(_factoryAddress).safeTransferFrom{gas : WITHDRAWAL_NFT_GAS_LIMIT}(
                 address(this),
                 op.toAddress,
-                op.nftL1TokenId
+                op.nftIndex
             ) {
                 // add nft to account at L1
-                _addAccountNft(op.toAddress, op.nftL1Address, op.nftIndex);
+                _addAccountNft(op.toAddress, _factoryAddress, op.nftIndex);
 
-                emit WithdrawNft(op.fromAccountIndex, op.nftL1Address, op.toAddress, op.nftL1TokenId);
+                emit WithdrawNft(op.fromAccountIndex, _factoryAddress, op.toAddress, op.nftIndex);
             }catch{
                 storePendingNFT(op);
-            }
-
-            bytes32 nftKey = keccak256(abi.encode(op.nftL1Address, op.nftL1TokenId));
-            if (l2Nfts[nftKey].nftContentHash == bytes32(0)) {
-                l2Nfts[nftKey] = L2NftInfo({
-                nftIndex : op.nftIndex,
-                creatorAccountIndex : op.creatorAccountIndex,
-                creatorTreasuryRate : op.creatorTreasuryRate,
-                nftContentHash : op.nftContentHash,
-                collectionId : uint16(op.collectionId)
-                });
             }
         } else {
             address _creatorAddress = getAddressByAccountNameHash(op.creatorAccountNameHash);
@@ -514,13 +508,11 @@ contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpg
                     creatorAccountIndex : _tx.creatorAccountIndex,
                     creatorTreasuryRate : _tx.creatorTreasuryRate,
                     nftIndex : _tx.nftIndex,
-                    nftL1Address : _tx.nftL1Address,
                     toAddress : toAddr,
                     gasFeeAccountIndex : 0,
                     gasFeeAssetId : 0,
                     gasFeeAssetAmount : 0,
                     nftContentHash : _tx.nftContentHash,
-                    nftL1TokenId : _tx.nftL1TokenId,
                     creatorAccountNameHash : _tx.accountNameHash,
                     collectionId : _tx.collectionId
                     });

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -59,7 +59,7 @@ async function main() {
     // get ERC721
     const ERC721 = await contractFactories.ERC721Factory.deploy('ZkBNB', 'ZEC', '0');
     await ERC721.deployed();
-    _genesisAccountRoot = '0x0183a70fce0e15afa57ec979de5e429ea547132f49d22631f16f2a2f41b08c1d';
+    _genesisAccountRoot = '0x2d78e504b2b50e926dabfa3b3a714ad4b026a7a07ebeee307b38bda021bad16e';
     const _listingFee = ethers.utils.parseEther('100');
     const _listingCap = 2 ** 16 - 1;
     const _listingToken = BUSDToken.address


### PR DESCRIPTION
### Description

This pr's target is to optimize the size of pubdata working with https://github.com/bnb-chain/zkbnb-crypto/pull/61, https://github.com/bnb-chain/zkbnb/pull/231 prs.

### Rationale

### Example

### Changes

Notable changes:
* reduce the length of zns name from 32 bytes to 20 bytes;
* remove `nftL1Adress` and `nftL1TokenId` from nft-related transactions;
* change parse code of pubdata according to https://github.com/bnb-chain/zkbnb-crypto/pull/61
* remove `Utils.bytesToUint256Arr` for pubdata which costs lots of gas