### PR TITLE
feat(assetGovernance): add BUSD token as gas token

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -83,6 +83,9 @@ contract Governance is Config {
         require(totalAssets < MAX_AMOUNT_OF_REGISTERED_ASSETS, "1f");
         // no free identifiers for tokens
 
+        if (totalAssets == 0) {
+            totalAssets = 1; // 0 => BNB asset,  1 => BUSD asset
+        }
         totalAssets++;
         uint16 newAssetId = totalAssets;
         // it is not `totalTokens - 1` because tokenId = 0 is reserved for eth

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -83,16 +83,16 @@ contract Governance is Config {
         require(totalAssets < MAX_AMOUNT_OF_REGISTERED_ASSETS, "1f");
         // no free identifiers for tokens
 
-        if (totalAssets == 0) {
-            totalAssets = 1; // 0 => BNB asset,  1 => BUSD asset
-        }
         totalAssets++;
         uint16 newAssetId = totalAssets;
         // it is not `totalTokens - 1` because tokenId = 0 is reserved for eth
 
         assetAddresses[newAssetId] = _asset;
         assetsList[_asset] = newAssetId;
-        emit NewAsset(_asset, newAssetId);
+
+        if (newAssetId > 1) { // 0 => BNB,  1 => BUSD
+            emit NewAsset(_asset, newAssetId);
+        }
     }
 
     function setAssetPaused(address _assetAddress, bool _assetPaused) external {

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -53,6 +53,8 @@ async function main() {
     await LEGToken.deployed()
     const REYToken = await contractFactories.TokenFactory.deploy(totalSupply, 'REY', 'REY')
     await REYToken.deployed()
+    const BUSDToken = await contractFactories.TokenFactory.deploy(totalSupply, 'BUSD', 'BUSD')
+    await BUSDToken.deployed()
 
     // get ERC721
     const ERC721 = await contractFactories.ERC721Factory.deploy('ZkBNB', 'ZEC', '0');
@@ -60,7 +62,7 @@ async function main() {
     _genesisAccountRoot = '0x0183a70fce0e15afa57ec979de5e429ea547132f49d22631f16f2a2f41b08c1d';
     const _listingFee = ethers.utils.parseEther('100');
     const _listingCap = 2 ** 16 - 1;
-    const _listingToken = LEGToken.address
+    const _listingToken = BUSDToken.address
     const baseNode = namehash.hash('legend')
     // deploy DeployFactory
     console.log('Deploy DeployFactory...')
@@ -106,6 +108,8 @@ async function main() {
     await addAssetTx0.wait()
     let addAssetTx1 = await assetGovernance.addAsset(REYToken.address)
     await addAssetTx1.wait()
+    let addAssetTx2 = await assetGovernance.addAsset(BUSDToken.address)
+    await addAssetTx2.wait()
 
     // Step 4: register zns base node
     console.log('Register ZNS base node...')
@@ -126,8 +130,10 @@ async function main() {
         upgradeGateKeeper: event[6],
         LEGToken: LEGToken.address,
         REYToken: REYToken.address,
+        BUSDToken: BUSDToken.address,
         ERC721: ERC721.address,
         znsPriceOracle: priceOracle.address,
+        DefaultNftFactory: DefaultNftFactory.address,
     })
 }
 

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -49,12 +49,12 @@ async function main() {
     // get ERC20s
     console.log('Deploy Tokens...')
     const totalSupply = ethers.utils.parseEther('100000000')
+    const BUSDToken = await contractFactories.TokenFactory.deploy(totalSupply, 'BUSD', 'BUSD')
+    await BUSDToken.deployed()
     const LEGToken = await contractFactories.TokenFactory.deploy(totalSupply, 'LEG', 'LEG')
     await LEGToken.deployed()
     const REYToken = await contractFactories.TokenFactory.deploy(totalSupply, 'REY', 'REY')
     await REYToken.deployed()
-    const BUSDToken = await contractFactories.TokenFactory.deploy(totalSupply, 'BUSD', 'BUSD')
-    await BUSDToken.deployed()
 
     // get ERC721
     const ERC721 = await contractFactories.ERC721Factory.deploy('ZkBNB', 'ZEC', '0');
@@ -104,12 +104,13 @@ async function main() {
     // Add tokens into assetGovernance
     // add asset
     console.log('Add tokens into assetGovernance asset list...')
+    let addAssetTx2 = await assetGovernance.addAsset(BUSDToken.address)
+    await addAssetTx2.wait()
+
     let addAssetTx0 = await assetGovernance.addAsset(LEGToken.address);
     await addAssetTx0.wait()
     let addAssetTx1 = await assetGovernance.addAsset(REYToken.address)
     await addAssetTx1.wait()
-    let addAssetTx2 = await assetGovernance.addAsset(BUSDToken.address)
-    await addAssetTx2.wait()
 
     // Step 4: register zns base node
     console.log('Register ZNS base node...')
@@ -128,9 +129,9 @@ async function main() {
         znsResolverProxy: event[4],
         zkbnbProxy: event[5],
         upgradeGateKeeper: event[6],
+        BUSDToken: BUSDToken.address,
         LEGToken: LEGToken.address,
         REYToken: REYToken.address,
-        BUSDToken: BUSDToken.address,
         ERC721: ERC721.address,
         znsPriceOracle: priceOracle.address,
         DefaultNftFactory: DefaultNftFactory.address,

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -104,10 +104,12 @@ async function main() {
     // Add tokens into assetGovernance
     // add asset
     console.log('Add tokens into assetGovernance asset list...')
-    let addAssetTx0 = await assetGovernance.addAsset(LEGToken.address);
+    let addAssetTx0 = await assetGovernance.addAsset(BUSDToken.address);
     await addAssetTx0.wait()
-    let addAssetTx1 = await assetGovernance.addAsset(REYToken.address)
+    let addAssetTx1 = await assetGovernance.addAsset(LEGToken.address);
     await addAssetTx1.wait()
+    let addAssetTx2 = await assetGovernance.addAsset(REYToken.address)
+    await addAssetTx2.wait()
 
     // Step 4: register zns base node
     console.log('Register ZNS base node...')

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -104,9 +104,6 @@ async function main() {
     // Add tokens into assetGovernance
     // add asset
     console.log('Add tokens into assetGovernance asset list...')
-    let addAssetTx2 = await assetGovernance.addAsset(BUSDToken.address)
-    await addAssetTx2.wait()
-
     let addAssetTx0 = await assetGovernance.addAsset(LEGToken.address);
     await addAssetTx0.wait()
     let addAssetTx1 = await assetGovernance.addAsset(REYToken.address)

--- a/scripts/deploy-keccak256/deposit.js
+++ b/scripts/deploy-keccak256/deposit.js
@@ -8,9 +8,9 @@ async function main() {
 
     // tokens
     const TokenFactory = await ethers.getContractFactory('ZkBNBRelatedERC20')
+    const BUSDToken = await TokenFactory.attach(addrs.BUSDToken)
     const LEGToken = await TokenFactory.attach(addrs.LEGToken)
     const REYToken = await TokenFactory.attach(addrs.REYToken)
-    const BUSDToken = await TokenFactory.attach(addrs.BUSDToken)
 
     // deposit bnb
     console.log('Deposit BNB...')
@@ -21,22 +21,22 @@ async function main() {
 
     // set allowance
     console.log('Set allowance...')
-    let setAllowanceTx = await LEGToken.approve(zkbnb.address, ethers.utils.parseEther('100000000000'))
+
+    let setAllowanceTx = await BUSDToken.approve(zkbnb.address, ethers.utils.parseEther('100000000000'))
+    await setAllowanceTx.wait()
+
+    setAllowanceTx = await LEGToken.approve(zkbnb.address, ethers.utils.parseEther('100000000000'))
     await setAllowanceTx.wait()
     setAllowanceTx = await REYToken.approve(zkbnb.address, ethers.utils.parseEther('100000000000'))
     await setAllowanceTx.wait()
 
-    setAllowanceTx = await BUSDToken.approve(zkbnb.address, ethers.utils.parseEther('100000000000'))
-    await setAllowanceTx.wait()
-
     // deposit bep20
     console.log('Deposit BEP20...')
-    let depositBEP20 = await zkbnb.depositBEP20(LEGToken.address, ethers.utils.parseEther('100'), 'sher')
+    let depositBEP20 = await zkbnb.depositBEP20(BUSDToken.address, ethers.utils.parseEther('100'), 'sher')
+    await depositBEP20.wait()
+    depositBEP20 = await zkbnb.depositBEP20(LEGToken.address, ethers.utils.parseEther('100'), 'sher')
     await depositBEP20.wait()
     depositBEP20 = await zkbnb.depositBEP20(REYToken.address, ethers.utils.parseEther('100'), 'sher')
-    await depositBEP20.wait()
-
-    depositBEP20 = await zkbnb.depositBEP20(BUSDToken.address, ethers.utils.parseEther('100'), 'sher')
     await depositBEP20.wait()
 }
 

--- a/scripts/deploy-keccak256/deposit.js
+++ b/scripts/deploy-keccak256/deposit.js
@@ -10,6 +10,7 @@ async function main() {
     const TokenFactory = await ethers.getContractFactory('ZkBNBRelatedERC20')
     const LEGToken = await TokenFactory.attach(addrs.LEGToken)
     const REYToken = await TokenFactory.attach(addrs.REYToken)
+    const BUSDToken = await TokenFactory.attach(addrs.BUSDToken)
 
     // deposit bnb
     console.log('Deposit BNB...')
@@ -24,11 +25,18 @@ async function main() {
     await setAllowanceTx.wait()
     setAllowanceTx = await REYToken.approve(zkbnb.address, ethers.utils.parseEther('100000000000'))
     await setAllowanceTx.wait()
+
+    setAllowanceTx = await BUSDToken.approve(zkbnb.address, ethers.utils.parseEther('100000000000'))
+    await setAllowanceTx.wait()
+
     // deposit bep20
     console.log('Deposit BEP20...')
     let depositBEP20 = await zkbnb.depositBEP20(LEGToken.address, ethers.utils.parseEther('100'), 'sher')
     await depositBEP20.wait()
     depositBEP20 = await zkbnb.depositBEP20(REYToken.address, ethers.utils.parseEther('100'), 'sher')
+    await depositBEP20.wait()
+
+    depositBEP20 = await zkbnb.depositBEP20(BUSDToken.address, ethers.utils.parseEther('100'), 'sher')
     await depositBEP20.wait()
 }
 

--- a/scripts/deploy-keccak256/register.js
+++ b/scripts/deploy-keccak256/register.js
@@ -28,8 +28,8 @@ async function main() {
     registerZnsTx = await zkbnb.registerZNS(
         gasName,
         '0x56744Dc80a3a520F0cCABf083AC874a4bf6433F3',
-        '0x0eac279f6815d42069a79374b0ce6d6bfe563935ddcdee8cc6c15c3618ea819c',
-        '0x26e2d4a47aedf792fb3ea7b97c6f5c7cebb32dd30afca3fe77e31be768fc6c0f',
+        '0x2c24415b75651673b0d7bbf145ac8d7cb744ba6926963d1d014836336df1317a',
+        '0x134f4726b89983a8e7babbf6973e7ee16311e24328edf987bb0fbe7a494ec91e',
         {
             value: gasRegisterFee,
         }

--- a/scripts/deploy-keccak256/register.js
+++ b/scripts/deploy-keccak256/register.js
@@ -28,8 +28,8 @@ async function main() {
     registerZnsTx = await zkbnb.registerZNS(
         gasName,
         '0x56744Dc80a3a520F0cCABf083AC874a4bf6433F3',
-        '0x2c24415b75651673b0d7bbf145ac8d7cb744ba6926963d1d014836336df1317a',
-        '0x134f4726b89983a8e7babbf6973e7ee16311e24328edf987bb0fbe7a494ec91e',
+        '0x0eac279f6815d42069a79374b0ce6d6bfe563935ddcdee8cc6c15c3618ea819c',
+        '0x26e2d4a47aedf792fb3ea7b97c6f5c7cebb32dd30afca3fe77e31be768fc6c0f',
         {
             value: gasRegisterFee,
         }


### PR DESCRIPTION
### Description

use BUSD as gas token, remove `NewAsset` event for BUSD since it is already added while `zkbnb` init

### Rationale

support BUSD as  gas token, if not remove `NewAsset` for BUSD, it is conflict between `new asset BUSD` and init gas token BUSD

This feature is corresponding with https://github.com/bnb-chain/zkbnb/pull/225/files

### Changes

Notable changes:
* remove `NewAsset` event for BUSD
* modify deploy script