### PR TITLE
fix: track nft which has been deposited

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -315,6 +315,9 @@ contract ZkBNB is UpgradeableMaster, Events, Storage, Config, ReentrancyGuardUpg
                 op.toAddress,
                 op.nftL1TokenId
             ) {
+                // add nft to account at L1
+                _addAccountNft(op.toAddress, _factoryAddress, op.nftIndex);
+
                 emit WithdrawNft(op.fromAccountIndex, op.nftL1Address, op.toAddress, op.nftL1TokenId);
             }catch{
                 storePendingNFT(op);


### PR DESCRIPTION
### Description

Track nft which has been deposited.

### Rationale

Currently, if a nft has been deposited, then when withdrawing it again, it will not be recored in the `accountNftMap`.

### Example

NA

### Changes

Notable changes:
* add tracking