### PR TITLE
Change state root because of poseidon hash integration

### DIFF
--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -59,7 +59,7 @@ async function main() {
     // get ERC721
     const ERC721 = await contractFactories.ERC721Factory.deploy('ZkBNB', 'ZEC', '0');
     await ERC721.deployed();
-    _genesisAccountRoot = '0x2d78e504b2b50e926dabfa3b3a714ad4b026a7a07ebeee307b38bda021bad16e';
+    _genesisAccountRoot = '0x07da02dceb062cef450527fcf0960f1e7b50f5cd5a639529b509c8614efe4890';
     const _listingFee = ethers.utils.parseEther('100');
     const _listingCap = 2 ** 16 - 1;
     const _listingToken = BUSDToken.address


### PR DESCRIPTION
### Description
This pr changes genesis state root because of poseidon integration, see https://github.com/bnb-chain/zkbnb-crypto/pull/65

### Rationale

### Example

### Changes

Notable changes:
* change genesis state root in deploy script
