### PR TITLE
add default private key for hardhat network config

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,12 +15,12 @@ module.exports = {
         // },
         local: {
             url: process.env.LOCAL_RPC || "http://127.0.0.1:8545",
-            accounts: (process.env.LOCAL_PRIVATE_KEY || '').split(','),
+            accounts: (process.env.LOCAL_PRIVATE_KEY || '0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1').split(','),
             timeout: 100000,
         },
         BSCTestnet: {
             url: process.env.BSC_TESTNET_RPC || "https://data-seed-prebsc-1-s1.binance.org:8545",
-            accounts: (process.env.BSC_TESTNET_PRIVATE_KEY || '').split(','),
+            accounts: (process.env.BSC_TESTNET_PRIVATE_KEY || '0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1').split(','),
             timeout: 300000,
             gas: 15000000
         },


### PR DESCRIPTION
### Description

Add fake private key for hardhat network config to fix zkbnb's auto integration test
### Rationale

Add a fake private key for each hardhat network

### Changes

Notable changes:
* Change the default value of the private key from empty string to a fake private key