### PR TITLE
Add unit tests for NFT functionalities

### DIFF
--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -116,7 +116,7 @@ contract Storage {
     uint16 collectionId;
   }
 
-  mapping(bytes32 => L2NftInfo) internal l2Nfts;
+  mapping(bytes32 => L2NftInfo) internal mintedNfts;
 
   /// @notice NFTFactories registered.
   /// @dev creator accountNameHash => CollectionId => NFTFactory

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -7,7 +7,6 @@ import "./interfaces/Events.sol";
 import "./lib/Utils.sol";
 import "./lib/Bytes.sol";
 import "./lib/TxTypes.sol";
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "./interfaces/INFTFactory.sol";

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -147,7 +147,7 @@ library TxTypes {
       _tx.creatorTreasuryRate,
       _tx.nftContentHash,
       _tx.accountNameHash,
-      _tx.collectionId // account name hash
+      _tx.collectionId
     );
   }
 

--- a/contracts/test-contracts/ZkBNBTest.sol
+++ b/contracts/test-contracts/ZkBNBTest.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../lib/TxTypes.sol";
+import "../interfaces/INFTFactory.sol";
+import "../ZkBNB.sol";
+import "../Storage.sol";
+
+contract ZkBNBTest is ZkBNB {
+  constructor(
+    address _governanceAddress,
+    address _verifierAddress,
+    address _additionalZkBNB,
+    address _znsController,
+    address _znsResolver
+  ) {
+    verifier = ZkBNBVerifier(_verifierAddress);
+    governance = Governance(_governanceAddress);
+    additionalZkBNB = AdditionalZkBNB(_additionalZkBNB);
+    znsController = ZNSController(_znsController);
+    znsResolver = PublicResolver(_znsResolver);
+  }
+
+  function getL2NftInfo(bytes32 nftKey) external view returns (L2NftInfo memory) {
+    return l2Nfts[nftKey];
+  }
+
+  function getPendingWithdrawnNFT(uint40 nftIndex) external view returns (TxTypes.WithdrawNft memory) {
+    return pendingWithdrawnNFTs[nftIndex];
+  }
+
+  function testWithdrawOrStoreNFT(TxTypes.WithdrawNft memory op) external {
+    return withdrawOrStoreNFT(op);
+  }
+
+  function testSetDefaultNFTFactory(INFTFactory _factory) external {
+    defaultNFTFactory = address(_factory);
+  }
+}

--- a/contracts/test-contracts/ZkBNBTest.sol
+++ b/contracts/test-contracts/ZkBNBTest.sol
@@ -21,8 +21,12 @@ contract ZkBNBTest is ZkBNB {
     znsResolver = PublicResolver(_znsResolver);
   }
 
-  function getL2NftInfo(bytes32 nftKey) external view returns (L2NftInfo memory) {
-    return l2Nfts[nftKey];
+  function getMintedL2NftInfo(bytes32 nftKey) external view returns (L2NftInfo memory) {
+    return mintedNfts[nftKey];
+  }
+
+  function getPriorityRequest(uint64 priorityRequestId) external view returns (PriorityTx memory) {
+    return priorityRequests[priorityRequestId];
   }
 
   function getPendingWithdrawnNFT(uint40 nftIndex) external view returns (TxTypes.WithdrawNft memory) {

--- a/test/nft.test.js
+++ b/test/nft.test.js
@@ -1,0 +1,198 @@
+const chai = require('chai');
+const { ethers } = require('hardhat');
+const { smock } = require('@defi-wonderland/smock');
+const assert = require('assert');
+
+const { expect } = chai;
+chai.use(smock.matchers);
+const abi = ethers.utils.defaultAbiCoder;
+
+describe('NFT functionality', function () {
+  let mockGovernance;
+  let mockZkBNBVerifier;
+  let mockZNSController;
+  let mockPublicResolver;
+  let mockNftFactory;
+
+  let zkBNB; // ZkBNBTest.sol
+  let additionalZkBNB; // AdditionalZkBNB.sol
+  let ERC721;
+
+  let owner, acc1;
+
+  const mockhash = ethers.utils.hexZeroPad(ethers.utils.hexlify(1), 32); // mock data
+
+  before(async function () {
+    [owner, acc1] = await ethers.getSigners();
+    const MockGovernance = await smock.mock('Governance');
+    mockGovernance = await MockGovernance.deploy();
+    await mockGovernance.deployed();
+
+    const MockZkBNBVerifier = await smock.mock('ZkBNBVerifier');
+    mockZkBNBVerifier = await MockZkBNBVerifier.deploy();
+    await mockZkBNBVerifier.deployed();
+
+    const MockZNSController = await smock.mock('ZNSController');
+    mockZNSController = await MockZNSController.deploy();
+    await mockZNSController.deployed();
+
+    const MockPublicResolver = await smock.mock('PublicResolver');
+    mockPublicResolver = await MockPublicResolver.deploy();
+    await mockPublicResolver.deployed();
+
+    const AdditionalZkBNB = await ethers.getContractFactory('AdditionalZkBNB');
+    additionalZkBNB = await AdditionalZkBNB.deploy();
+    await additionalZkBNB.deployed();
+
+    const Utils = await ethers.getContractFactory('Utils');
+    utils = await Utils.deploy();
+    await utils.deployed();
+
+    const ZkBNBTest = await ethers.getContractFactory('ZkBNBTest', {
+      libraries: {
+        Utils: utils.address,
+      },
+    });
+    zkBNB = await ZkBNBTest.deploy(
+      mockGovernance.address,
+      mockZkBNBVerifier.address,
+      additionalZkBNB.address,
+      mockZNSController.address,
+      mockPublicResolver.address,
+    );
+    await zkBNB.deployed();
+
+    const MockNftFactory = await smock.mock('ZkBNBNFTFactory');
+    mockNftFactory = await MockNftFactory.deploy('FooNFT', 'FOO', 'ipfs://', zkBNB.address);
+    await mockNftFactory.deployed();
+
+    await zkBNB.testSetDefaultNFTFactory(mockNftFactory.address);
+  });
+
+  it('get NFT Factory', async function () {
+    expect(await zkBNB.defaultNFTFactory()).to.equal(mockNftFactory.address);
+  });
+
+  it.skip('register NFT Factory', async function () {});
+
+  describe('withdraw and mint a NFT', function () {
+    const mockNftIndex = 0;
+
+    it('NFT is not there before `withdraw', async function () {
+      const nftKey = ethers.utils.keccak256(abi.encode(['address', 'uint256'], [mockNftFactory.address, mockNftIndex]));
+      const _l2Nft = await zkBNB.getL2NftInfo(nftKey);
+
+      expect(_l2Nft['nftContentHash']).to.equal(ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32));
+    });
+
+    it('should mint and then withdraw', async function () {
+      mockZNSController.getOwner.returns(acc1.address);
+
+      const withdrawOp = {
+        txType: 11, // WithdrawNft
+        fromAccountIndex: 1,
+        creatorAccountIndex: 0,
+        creatorTreasuryRate: 5,
+        nftIndex: mockNftIndex,
+        toAddress: acc1.address,
+        gasFeeAccountIndex: 1,
+        gasFeeAssetId: 0, //BNB
+        gasFeeAssetAmount: 666,
+        nftContentHash: mockhash,
+        creatorAccountNameHash: mockhash,
+        collectionId: 0,
+      };
+
+      await expect(await zkBNB.testWithdrawOrStoreNFT(withdrawOp))
+        .to.emit(zkBNB, 'WithdrawNft')
+        .withArgs(1, mockNftFactory.address, acc1.address, mockNftIndex);
+    });
+
+    it('NFT should be minted', async function () {
+      const nftKey = ethers.utils.keccak256(abi.encode(['address', 'uint256'], [mockNftFactory.address, mockNftIndex]));
+      const l2Nft = await zkBNB.getL2NftInfo(nftKey);
+
+      expect(l2Nft['nftIndex']).to.equal(mockNftIndex);
+      expect(l2Nft['creatorAccountIndex']).to.equal(0);
+      expect(l2Nft['creatorTreasuryRate']).to.equal(5);
+      expect(l2Nft['nftContentHash']).to.equal(mockhash);
+      expect(l2Nft['collectionId']).to.equal(0);
+    });
+
+    it('L1 NFT should be owned by acc1', async function () {
+      expect(await mockNftFactory.ownerOf(mockNftIndex)).to.equal(acc1.address);
+      expect(await mockNftFactory.balanceOf(acc1.address)).to.equal(1);
+    });
+  });
+
+  describe('withdraw NFT on mint failure', async function () {
+    const nftIndex = 2;
+
+    it('store pending withdrawn NFT on mint failure', async function () {
+      mockZNSController.getOwner.returns(acc1.address);
+      mockNftFactory.mintFromZkBNB.reverts();
+
+      const withdrawOp2 = {
+        txType: 11, // WithdrawNft
+        fromAccountIndex: 1,
+        creatorAccountIndex: 0,
+        creatorTreasuryRate: 5,
+        nftIndex,
+        toAddress: acc1.address,
+        gasFeeAccountIndex: 1,
+        gasFeeAssetId: 0, //BNB
+        gasFeeAssetAmount: 666,
+        nftContentHash: mockhash,
+        creatorAccountNameHash: mockhash,
+        collectionId: 0,
+      };
+
+      await expect(await zkBNB.testWithdrawOrStoreNFT(withdrawOp2))
+        .to.emit(zkBNB, 'WithdrawalNFTPending')
+        .withArgs(nftIndex);
+
+      const result = await zkBNB.getPendingWithdrawnNFT(nftIndex);
+
+      assert.deepStrictEqual(withdrawOp2, {
+        txType: result['txType'],
+        fromAccountIndex: result['fromAccountIndex'],
+        creatorAccountIndex: result['creatorAccountIndex'],
+        creatorTreasuryRate: result['creatorTreasuryRate'],
+        nftIndex: result['nftIndex'],
+        toAddress: result['toAddress'],
+        gasFeeAccountIndex: result['gasFeeAccountIndex'],
+        gasFeeAssetId: result['gasFeeAssetId'],
+        gasFeeAssetAmount: result['gasFeeAssetAmount'],
+        nftContentHash: result['nftContentHash'],
+        creatorAccountNameHash: result['creatorAccountNameHash'],
+        collectionId: result['collectionId'],
+      });
+    });
+
+    it('NFT should not be minted', async function () {
+      const nftKey = ethers.utils.keccak256(abi.encode(['address', 'uint256'], [mockNftFactory.address, nftIndex]));
+      const l2Nft = await zkBNB.getL2NftInfo(nftKey);
+      assert.equal(l2Nft['nftContentHash'], 0);
+    });
+
+    it('withdraw pending NFT balance', async function () {
+      mockZNSController.getOwner.returns(acc1.address);
+
+      await zkBNB.withdrawPendingNFTBalance(nftIndex);
+
+      const { nftContentHash: _nftContentHash } = await zkBNB.getPendingWithdrawnNFT(nftIndex);
+
+      assert.equal(_nftContentHash, 0);
+
+      await expect(await zkBNB.withdrawPendingNFTBalance(nftIndex))
+        .to.emit(zkBNB, 'WithdrawNft')
+        .withArgs(1, mockNftFactory.address, acc1.address, nftIndex);
+
+      const result = await zkBNB.withdrawPendingNFTBalance(nftIndex);
+    });
+  });
+
+  it.skip('deposit NFT', async function () {});
+
+  it.skip('request Full Exit Nft', async function () {});
+});


### PR DESCRIPTION
### Description
Add unit tests for NFT functionalities. Created `ZkBNBTest.sol` to test internal functions.

### Example
```
npx hardhat test test/zkBNB.nft.test.js


  NFT functionality
    ✔ check default NFT Factory
    - request Full Exit Nft
    withdraw and mint a NFT
      ✔ NFT is not minted before withdrawal
      ✔ should done mint and then withdraw
      ✔ NFT should be minted
      ✔ L1 NFT should be owned by acc1
    withdraw NFT on mint failure
      ✔ store pending withdrawn NFT on mint failure
      ✔ the NFT should not be minted
      ✔ withdraw should succeed on retry
      ✔ the NFT should be minted after withdrawal
      ✔ the NFT should not be pending after withdrawal
    deposit NFT
      ✔ deposit the 1st withdrawn NFT
      ✔ the deposit priority request should be added
      ✔ the nft should be deleted from L1 account after deposition
      ✔ should fail to deposit a NFT which is not created by layer2


  14 passing (1s)
  1 pending
```
### Changes

Notable changes:
* fixed https://github.com/bnb-chain/zkbnb-contract/issues/36
* added `ZkBNBTest.sol`
* added test cases for NFT deposit and withdrawal