### PR TITLE
Access control added to the UpgradeableMaster

### DIFF
--- a/CONTRACTS_DESIGN.md
+++ b/CONTRACTS_DESIGN.md
@@ -341,26 +341,5 @@ interface Upgradeable {
     /// @param newTargetInitializationParameters New target initialization parameters
     function upgradeTarget(address newTarget, bytes calldata newTargetInitializationParameters) external;
 }
-
-interface UpgradeableMaster {
-    /// @notice Notice period before activation preparation status of upgrade mode
-    function getNoticePeriod() external returns (uint256);
-
-    /// @notice Notifies contract that notice period started
-    function upgradeNoticePeriodStarted() external;
-
-    /// @notice Notifies contract that upgrade preparation status is activated
-    function upgradePreparationStarted() external;
-
-    /// @notice Notifies contract that upgrade canceled
-    function upgradeCanceled() external;
-
-    /// @notice Notifies contract that upgrade finishes
-    function upgradeFinishes() external;
-
-    /// @notice Checks that contract is ready for upgrade
-    /// @return bool flag indicating that contract is ready for upgrade
-    function isReadyForUpgrade() external returns (bool);
-}
 ```
-All proxies of upgradeable contracts should implement `Upgradeable` and `UpgradeableMaster` interface for management of `UpgradeGatekeeper`.
+All proxies of upgradeable contracts should implement `Upgradeable` interface for management of `UpgradeGatekeeper`.

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -153,6 +153,11 @@ async function main() {
     );
   await setBaseNodeTx.wait();
 
+  // NOTE: UpgradeGateKeeper must be granted permission to invoke the relevant method of the notification period
+  console.log('Granted permission...');
+  const UPGRADE_GATEKEEPER_ROLE = await upgradeableMaster.UPGRADE_GATEKEEPER_ROLE();
+  await upgradeableMaster.grantRole(UPGRADE_GATEKEEPER_ROLE, event[6] /* upgradeGateKeeper.address */);
+
   // Save addresses into JSON
   console.log('Save deployed contract addresses...');
   saveDeployedAddresses('info/addresses.json', {


### PR DESCRIPTION
### Description

Access control added to the UpgradeableMaster

### Rationale

UpgradeableMaster should separate the privilege to call the notification period functions from the privilege to manage it

Notable changes:
* UpgradeableMaster extends AccessControl Contract
* Add unit test case
* Add grant role script in the deploy