### PR TITLE
Add constraints for adding asset

### DIFF
--- a/contracts/AssetGovernance.sol
+++ b/contracts/AssetGovernance.sol
@@ -81,9 +81,9 @@ contract AssetGovernance is ReentrancyGuard {
     function addAsset(address _assetAddress) external {
         // Impossible to add more tokens using this contract
         require(governance.totalAssets() < listingCap, "can't add more tokens");
-        // Check access: if address zero is a lister, any address can add asset
-        require(tokenLister[msg.sender] || tokenLister[address(0)], "no access");
         if (!tokenLister[msg.sender]) {
+            // Check access: if address zero is a lister, any address can add asset
+            require(tokenLister[address(0)], "no access");
             // Collect fees
             bool feeTransferOk = Utils.transferFromERC20(listingFeeToken, msg.sender, treasury, listingFee);
             require(feeTransferOk, "fee transfer failed");


### PR DESCRIPTION
### Description

Add constraints for adding asset, if the address 0 is token lister, any address can add asset

### Rationale

add these code in AssetGovernance
```
// Check access: if address zero is a lister, any address can add asset
    require(tokenLister[msg.sender] || tokenLister[address(0)], "no access");
```

### Changes

Notable changes:
* Only after added address 0 as lister, any address can add asset