### PR TITLE
fix nft token uri concat issue

### DIFF
--- a/contracts/lib/Bytes.sol
+++ b/contracts/lib/Bytes.sol
@@ -10,6 +10,32 @@ pragma solidity ^0.8.0;
 // 2) We load W from memory into out, last N bytes of W are placed into out
 
 library Bytes {
+  bytes16 private constant _SYMBOLS = "0123456789abcdef";
+
+  /**
+   * @dev Converts a `bytes32` to its ASCII `string` hexadecimal representation with fixed length.
+   */
+  function bytes32ToHexString(bytes32 bytesValue, bool prefix) internal pure returns (string memory) {
+    uint256 uint256Value = uint256(bytesValue);
+    uint skip;
+    bytes memory buffer;
+    if (prefix) {
+      skip = 2;
+      buffer = new bytes(66);
+      buffer[0] = "0";
+      buffer[1] = "x";
+    } else {
+      skip = 0;
+      buffer = new bytes(64);
+    }
+    for (uint256 i = 65; i > 1; --i) {
+      buffer[i + skip - 2] = _SYMBOLS[uint256Value & 0xf];
+      uint256Value >>= 4;
+    }
+    require(uint256Value == 0, "Strings: hex length insufficient");
+    return string(buffer);
+  }
+
   function toBytesFromUInt16(uint16 self) internal pure returns (bytes memory _bts) {
     return toBytesFromUIntTruncated(uint256(self), 2);
   }
@@ -147,11 +173,7 @@ library Bytes {
   // Get slice from bytes arrays
   // Returns the newly created 'bytes memory'
   // NOTE: theoretically possible overflow of (_start + _length)
-  function slice(
-    bytes memory _bytes,
-    uint256 _start,
-    uint256 _length
-  ) internal pure returns (bytes memory) {
+  function slice(bytes memory _bytes, uint256 _start, uint256 _length) internal pure returns (bytes memory) {
     require(_bytes.length >= (_start + _length), "Z");
     // bytes length is less then start byte + length bytes
 

--- a/contracts/test-contracts/BytesTest.sol
+++ b/contracts/test-contracts/BytesTest.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "../lib/Bytes.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+
+contract BytesTest {
+  function bytes32ToHexString(bytes32 hash) external view returns (string memory) {
+    return Bytes.bytes32ToHexString(hash, true);
+  }
+
+  function bytes32ToHexStringWithoutPrefix(bytes32 hash) external view returns (string memory) {
+    return Bytes.bytes32ToHexString(hash, false);
+  }
+
+  function concatStringAndBytes32(string calldata prefix, bytes32 hash) external view returns (string memory) {
+    return string(abi.encodePacked(prefix, Bytes.bytes32ToHexString(hash, false)));
+  }
+}

--- a/test/bytes.test.js
+++ b/test/bytes.test.js
@@ -1,0 +1,21 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+// Start test block
+describe('BytesTest', function () {
+  beforeEach(async function () {
+    const BytesTest = await ethers.getContractFactory('BytesTest');
+    this.bytesTest = await BytesTest.deploy();
+  });
+
+  it('bytes test', async function () {
+    const hash = '0x3579B1273F940172FEBE72B0BFB51C15F49F23E558CA7F03DFBA2D97D8287A30'.toLowerCase();
+    const hexString = await this.bytesTest.bytes32ToHexString(hash);
+    expect(hexString).to.equal(hash);
+    const hexString2 = await this.bytesTest.bytes32ToHexStringWithoutPrefix(hash);
+    expect(hexString2).to.equal(hash.substring(2));
+    const prefix = 'ipfs://f01701220';
+    const result = await this.bytesTest.concatStringAndBytes32(prefix, hash);
+    expect(result).to.equal(`${prefix}${hash.substring(2)}`);
+  });
+});

--- a/test/nft/ZkBNB.nft.test.js
+++ b/test/nft/ZkBNB.nft.test.js
@@ -23,6 +23,7 @@ describe('NFT functionality', function () {
   let utils;
 
   const mockHash = ethers.utils.hexZeroPad(ethers.utils.hexlify(1), 32); // mock data
+  const baseURI = `ipfs://f01701220`;
 
   before(async function () {
     [owner, acc1, acc2] = await ethers.getSigners();
@@ -72,14 +73,14 @@ describe('NFT functionality', function () {
     await zkBNB.initialize(initParams);
 
     const ZkBNBNFTFactory = await ethers.getContractFactory('ZkBNBNFTFactory');
-    zkBNBNFTFactory = await ZkBNBNFTFactory.deploy('ZkBNBNft', 'Zk', 'ipfs://', zkBNB.address);
+    zkBNBNFTFactory = await ZkBNBNFTFactory.deploy('ZkBNBNft', 'Zk', baseURI, zkBNB.address);
     await zkBNBNFTFactory.deployed();
     assert.equal(await zkBNBNFTFactory.name(), 'ZkBNBNft');
     assert.equal(await zkBNBNFTFactory.symbol(), 'Zk');
-    assert.equal(await zkBNBNFTFactory._base(), 'ipfs://');
+    assert.equal(await zkBNBNFTFactory._base(), baseURI);
 
     const MockNftFactory = await smock.mock('ZkBNBNFTFactory');
-    mockNftFactory = await MockNftFactory.deploy('FooNft', 'FOO', 'ipfs://', zkBNB.address);
+    mockNftFactory = await MockNftFactory.deploy('FooNft', 'FOO', baseURI, zkBNB.address);
     await mockNftFactory.deployed();
     await mockGovernance.setVariable('networkGovernor', owner.address);
 
@@ -341,9 +342,7 @@ describe('NFT functionality', function () {
     // TODO: Complete tokenURI implementation in ZkBNBNFTFactory.sol
     it('check tokenURI', async function () {
       await expect(zkBNBNFTFactory.tokenURI(99)).to.be.revertedWith('tokenId not exist');
-      const expectUri = ethers.utils.toUtf8String(
-        ethers.utils.solidityPack(['string', 'bytes32'], ['ipfs://', mockHash]),
-      );
+      const expectUri = `${baseURI}${mockHash.substring(2)}`;
 
       await expect(await zkBNBNFTFactory.tokenURI(tokenId)).to.be.equal(expectUri);
     });


### PR DESCRIPTION
### Description

fix tokenURI concat issue
### Rationale

Fixed the issue that the tokenURI method could not return the correct tokenURI

### Changes

Notable changes:
* add bytes32 to hex string method
* update tokenURI concat logic