### PR TITLE
Add access control from nft base uri setter

### DIFF
--- a/contracts/ZkBNBNFTFactory.sol
+++ b/contracts/ZkBNBNFTFactory.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./interfaces/INFTFactory.sol";
 import "./lib/Bytes.sol";
 
-contract ZkBNBNFTFactory is ERC721, INFTFactory, Ownable {
+contract ZkBNBNFTFactory is ERC721, INFTFactory, Ownable, ReentrancyGuard {
   // Optional mapping from token ID to token content hash
   mapping(uint256 => bytes32) private _contentHashes;
 
@@ -28,7 +29,7 @@ contract ZkBNBNFTFactory is ERC721, INFTFactory, Ownable {
     uint256 _nftTokenId,
     bytes32 _nftContentHash,
     bytes memory _extraData
-  ) external override {
+  ) external override nonReentrant {
     require(_msgSender() == _zkbnbAddress, "only zkbnbAddress");
     // Minting allowed only from zkbnb
     _safeMint(_toAddress, _nftTokenId);

--- a/contracts/ZkBNBNFTFactory.sol
+++ b/contracts/ZkBNBNFTFactory.sol
@@ -2,10 +2,11 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/INFTFactory.sol";
 import "./lib/Bytes.sol";
 
-contract ZkBNBNFTFactory is ERC721, INFTFactory {
+contract ZkBNBNFTFactory is ERC721, INFTFactory, Ownable {
   // Optional mapping from token ID to token content hash
   mapping(uint256 => bytes32) private _contentHashes;
 
@@ -57,7 +58,7 @@ contract ZkBNBNFTFactory is ERC721, INFTFactory {
     return string(abi.encodePacked(_base, Bytes.bytes32ToHexString(_contentHashes[tokenId], false)));
   }
 
-  function updateBaseUri(string memory base) external {
+  function updateBaseUri(string memory base) external onlyOwner {
     _base = base;
   }
 }

--- a/test/nft/ZkBNB.nft.test.js
+++ b/test/nft/ZkBNB.nft.test.js
@@ -373,5 +373,12 @@ describe('NFT functionality', function () {
       await zkBNBNFTFactory.updateBaseUri(newBase);
       await expect(await zkBNBNFTFactory._base()).to.be.equal(newBase);
     });
+
+    it('non-owner should fail to update base URI', async function () {
+      const newBase = 'bar://';
+      await expect(zkBNBNFTFactory.connect(acc2).updateBaseUri(newBase)).to.be.revertedWith(
+        'Ownable: caller is not the owner',
+      );
+    });
   });
 });


### PR DESCRIPTION
### Description
- The `updateBaseUri` function is missing access control, added unit test for it as well.
- Added reentrancy protection over `mintFromZkBNB`

