### PR TITLE
Set new genesis account root

### DIFF
--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -67,7 +67,7 @@ async function main() {
   // get ERC721
   const ERC721 = await contractFactories.ERC721Factory.deploy('ZkBNB', 'ZEC', '0');
   await ERC721.deployed();
-  const _genesisAccountRoot = '0x07da02dceb062cef450527fcf0960f1e7b50f5cd5a639529b509c8614efe4890';
+  const _genesisAccountRoot = '0x18195ae3b8f5962236067a051c3a5f697a19de8442849677dbbee328107cca81';
   const _listingFee = ethers.utils.parseEther('100');
   const _listingCap = 2 ** 16 - 1;
   const _listingToken = BUSDToken.address;


### PR DESCRIPTION
### Description

Since poseidon hash calculation is changed, we need to update genesis account root in deploy script

### Changes

Notable changes:
* updated `deploy.js`