### PR TITLE
fix ownership issue with zns withdraw

### DIFF
--- a/contracts/DeployFactory.sol
+++ b/contracts/DeployFactory.sol
@@ -171,5 +171,6 @@ contract DeployFactory {
 
   function finalizeZNSController(ZNSController _znsController, address _zkbnb) internal {
     _znsController.addController(_zkbnb);
+    _znsController.transferOwnership(msg.sender); //The sender can withdraw the ZNS account registration fees
   }
 }


### PR DESCRIPTION
### Description
Currently, the ZNSController is owned by DeployFactory. However, the DeployFactory self-destructs after deployment. So, this leaves ZNSController without an owner and no way to withdraw funds.

This fix solves this issue


Notable changes:
* DeployFactory