### PR TITLE
fix FullExitNftPubData offset and add unit test

### DIFF
--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -369,9 +369,8 @@ library TxTypes {
     // nft content type
     (offset, parsed.nftContentType) = Bytes.readUInt8(_data, offset);
 
-    // 1 + 4 + 4 + 2 + 5 + 2 + 20 + 20 + 4 + 1 + x = 121
-    // x = 58
-    offset += 58;
+    // 1 + 4 + 4 + 2 + 5 + 2 + 20 + 20 + 32 + 1 + x = 121
+    offset += 30;
     require(offset == PACKED_TX_PUBDATA_BYTES, "7N");
     return parsed;
   }

--- a/contracts/test-contracts/TxTypesTest.sol
+++ b/contracts/test-contracts/TxTypesTest.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../lib/TxTypes.sol";
+
+contract TxTypesTest {
+  function testWriteFullExitNftPubData(TxTypes.FullExitNft memory _tx) external pure returns (bytes memory buf) {
+    return TxTypes.writeFullExitNftPubDataForPriorityQueue(_tx);
+  }
+
+  function testReadFullExitNftPubData(bytes memory _data) external pure returns (TxTypes.FullExitNft memory parsed) {
+    return TxTypes.readFullExitNftPubData(_data);
+  }
+}

--- a/test/TxTypes.test.ts
+++ b/test/TxTypes.test.ts
@@ -1,0 +1,36 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+
+describe('TxTypesTest', function () {
+  let owner, acc1;
+
+  beforeEach(async function () {
+    [owner, acc1] = await ethers.getSigners();
+
+    const TxTypesTest = await ethers.getContractFactory('TxTypesTest');
+    this.txTypesTest = await TxTypesTest.deploy();
+  });
+
+  it('FullExitNft pubdata should be serialized and deserialized correclty', async function () {
+    const fullExitNft = {
+      txType: 9,
+      accountIndex: 1,
+      creatorAccountIndex: 2,
+      creatorTreasuryRate: 0,
+      nftIndex: 0,
+      collectionId: 1,
+      owner: owner.address,
+      creatorAddress: acc1.address, // creatorAddress
+      nftContentHash: ethers.constants.HashZero,
+      nftContentType: 0, // New added
+    };
+
+    const encoded = await this.txTypesTest.testWriteFullExitNftPubData(fullExitNft);
+    const parsed = await this.txTypesTest.testReadFullExitNftPubData(encoded);
+
+    expect(parsed['nftIndex']).to.equal(fullExitNft.nftIndex);
+    expect(parsed['owner']).to.equal(fullExitNft.owner);
+    expect(parsed['creatorAddress']).to.equal(fullExitNft.creatorAddress);
+  });
+});


### PR DESCRIPTION
### Description

fixed the wrong bytes offset when deserialize FullExitNft pubdata