### PR TITLE
Multi  protocol token uri support

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -237,7 +237,6 @@ contract Governance is Config, Initializable {
   /// @param baseURI nft baseURI, used to generate tokenURI of nft
   function updateBaseURI(uint8 nftContentType, string memory baseURI) external {
     requireGovernor(msg.sender);
-    // todo check nftContentType is valid
     nftBaseURIs[nftContentType] = baseURI;
   }
 
@@ -245,8 +244,6 @@ contract Governance is Config, Initializable {
   /// @param nftContentType which protocol to store nft content
   /// @param nftContentHash hash of nft content
   function getNftTokenURI(uint8 nftContentType, bytes32 nftContentHash) external view returns (string memory tokenURI) {
-    // todo check nftContentType is valid
-    require(bytes(nftBaseURIs[nftContentType]).length > 0, "baseURI has not set");
     tokenURI = string(abi.encodePacked(nftBaseURIs[nftContentType], Bytes.bytes32ToHexString(nftContentHash, false)));
   }
 }

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -553,7 +553,7 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
           op.creatorAddress,
           op.toAddress,
           op.nftIndex,
-          op.nftContentHash,
+          governance.getNftTokenURI(op.nftContentType, op.nftContentHash),
           _emptyExtraData
         )
       {

--- a/contracts/ZkBNBNFTFactory.sol
+++ b/contracts/ZkBNBNFTFactory.sol
@@ -1,70 +1,49 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./interfaces/INFTFactory.sol";
 import "./lib/Bytes.sol";
 import "./lib/Ownable2Step.sol";
 
-contract ZkBNBNFTFactory is ERC721, INFTFactory, Ownable2Step, ReentrancyGuard {
-  // Optional mapping from token ID to token content hash
-  mapping(uint256 => bytes32) private _contentHashes;
-
+contract ZkBNBNFTFactory is ERC721URIStorage, INFTFactory, Ownable2Step, ReentrancyGuard {
   // tokenId => creator
   mapping(uint256 => address) private _nftCreators;
-
-  string public _base;
 
   address private _zkbnbAddress;
 
   constructor(
     string memory name,
     string memory symbol,
-    string memory base,
     address zkbnbAddress,
     address owner
   ) ERC721(name, symbol) Ownable2Step(owner) {
     _zkbnbAddress = zkbnbAddress;
-    _base = base;
-  }
-
-  function updateBaseUri(string memory base) external onlyOwner {
-    _base = base;
   }
 
   function mintFromZkBNB(
     address _creatorAddress,
     address _toAddress,
     uint256 _nftTokenId,
-    bytes32 _nftContentHash,
+    string memory _nftTokenURI,
     bytes memory _extraData
   ) external override nonReentrant {
     require(_msgSender() == _zkbnbAddress, "only zkbnbAddress");
     // Minting allowed only from zkbnb
     _safeMint(_toAddress, _nftTokenId);
-    _contentHashes[_nftTokenId] = _nftContentHash;
+    _setTokenURI(_nftTokenId, _nftTokenURI);
     _nftCreators[_nftTokenId] = _creatorAddress;
-    emit MintNFTFromZkBNB(_creatorAddress, _toAddress, _nftTokenId, _nftContentHash, _extraData);
-  }
-
-  function getContentHash(uint256 _tokenId) external view returns (bytes32) {
-    return _contentHashes[_tokenId];
+    emit MintNFTFromZkBNB(_creatorAddress, _toAddress, _nftTokenId, _extraData);
   }
 
   function getCreator(uint256 _tokenId) external view returns (address) {
     return _nftCreators[_tokenId];
   }
 
-  function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-    require(_exists(tokenId), "tokenId not exist");
-    return string(abi.encodePacked(_base, Bytes.bytes32ToHexString(_contentHashes[tokenId], false)));
-  }
-
   function _beforeTokenTransfer(address, address to, uint256 tokenId) internal virtual {
     // Sending to address `0` means that the token is getting burned.
     if (to == address(0)) {
-      delete _contentHashes[tokenId];
       delete _nftCreators[tokenId];
     }
   }

--- a/contracts/interfaces/INFTFactory.sol
+++ b/contracts/interfaces/INFTFactory.sol
@@ -7,7 +7,6 @@ interface INFTFactory {
     address indexed _creatorAddress,
     address indexed _toAddress,
     uint256 _nftTokenId,
-    bytes32 _nftContentHash,
     bytes _extraData
   );
 
@@ -15,7 +14,7 @@ interface INFTFactory {
     address _creatorAddress,
     address _toAddress,
     uint256 _nftTokenId,
-    bytes32 _nftContentHash,
+    string memory _nftTokenURI,
     bytes memory _extraData
   ) external;
 }

--- a/contracts/test-contracts/ZkBNBTest.sol
+++ b/contracts/test-contracts/ZkBNBTest.sol
@@ -71,16 +71,10 @@ contract ZkBNBTest is ZkBNB {
     address _creatorAddress,
     address _toAddress,
     uint256 _nftTokenId,
-    bytes32 _nftContentHash,
+    string memory _nftTokenURI,
     bytes memory _extraData
   ) external {
     return
-      INFTFactory(defaultNFTFactory).mintFromZkBNB(
-        _creatorAddress,
-        _toAddress,
-        _nftTokenId,
-        _nftContentHash,
-        _extraData
-      );
+      INFTFactory(defaultNFTFactory).mintFromZkBNB(_creatorAddress, _toAddress, _nftTokenId, _nftTokenURI, _extraData);
   }
 }

--- a/test/nft/ZkBNB.nft.test.js
+++ b/test/nft/ZkBNB.nft.test.js
@@ -416,6 +416,7 @@ describe('NFT functionality', function () {
       )
         .to.emit(zkBNBNFTFactory, 'MintNFTFromZkBNB')
         .withArgs(acc1.address, acc2.address, tokenId, extraData);
+      assert.strictEqual(await zkBNBNFTFactory.tokenURI(tokenId), tokenURI);
     });
 
     // // delete contentHash map


### PR DESCRIPTION
### Description

now NFT metadata store in IPFS, and contentHash store in a NFTFactory(ERC721) contract. tokenURI = baseURI + contentHash.

to support multi storage protocol , remove contentHash mapping , change NFTFactory(ERC721) to ERC721Stroage, tokenURI is generate from input contentHash and baseURI  when mint, and store in tokenId=>tokenURI mapping.


### Rationale

Support multi storage protocol (ipfs/greenfield...) to store nft metadata

### Example


### Changes

Notable changes:
* change NFTFactory from ERC721 to ERC721Storage, save tokenURI of every tokenId. remove baseURI and contentHash logic in NFTFactory.
* new mapping nftBaseURIs in Governance.sol to store baseURI of nftContentType( 0-ipfs/1-greenfiled ...)
* tokenURI related change in zkBNB.withdrawOrStoreNFT