### PR TITLE
padding the compressed pubdata in commit block

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -266,6 +266,14 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
       require(_newBlock.timestamp >= _previousBlock.timestamp, "g");
     }
 
+    // padding zero transactions
+    if (_newBlock.publicData.length < _newBlock.blockSize * TxTypes.PACKED_TX_PUBDATA_BYTES) {
+      _newBlock.publicData = bytes.concat(
+        _newBlock.publicData,
+        new bytes(_newBlock.blockSize * TxTypes.PACKED_TX_PUBDATA_BYTES - _newBlock.publicData.length)
+      );
+    }
+
     // Check onchain operations
     (bytes32 pendingOnchainOpsHash, uint64 priorityReqCommitted) = collectOnchainOps(_newBlock);
 


### PR DESCRIPTION
### Description
There will be many empty transactions in pubdata before, in order to reduce gas, when zkbnb commits blocks, it will remove empty transactions, but in order not to affect the proof, the contract needs to padding these removed empty transactions at the end of the pubdata.


### Rationale
This is a compatibility change and will not have any impact


### Changes

Notable changes:
* add padding pubdata logic in commitBLocks