### PR TITLE
fix requestFullExitNft interface by removing unused parameters

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -724,15 +724,8 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
 
   /// @notice Register full exit nft request - pack pubdata, add priority request
   /// @param _accountIndex Numerical id of the account
-  /// @param _creatorAddress creator's L1 address
   /// @param _nftIndex account NFT index in zkbnb network
-  /// @param _nftContentType the type of storage protocol
-  function requestFullExitNft(
-    uint32 _accountIndex,
-    address _creatorAddress,
-    uint32 _nftIndex,
-    uint8 _nftContentType
-  ) public onlyActive {
+  function requestFullExitNft(uint32 _accountIndex, uint32 _nftIndex) public onlyActive {
     // Priority Queue request
     TxTypes.FullExitNft memory _tx = TxTypes.FullExitNft({
       txType: uint8(TxTypes.TxType.FullExitNft),
@@ -742,9 +735,9 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
       nftIndex: _nftIndex,
       collectionId: 0, // unknown
       owner: msg.sender, // accountNameHahsh => owner
-      creatorAddress: _creatorAddress, // creatorAccountNameHash => creatorAddress
+      creatorAddress: address(0), // unknown
       nftContentHash: bytes32(0x0), // unknown,
-      nftContentType: _nftContentType // New added
+      nftContentType: 0 //unkown
     });
     bytes memory pubData = TxTypes.writeFullExitNftPubDataForPriorityQueue(_tx);
     addPriorityRequest(TxTypes.TxType.FullExitNft, pubData);

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -343,7 +343,7 @@ library TxTypes {
       _tx.nftIndex,
       uint16(0), // collection id
       _tx.owner, //
-      _tx.creatorAddress, // creator account name hash
+      address(0), // creator address
       bytes32(0), // nft content hash
       uint8(0) // nft content type
     );

--- a/test/TxTypes.test.ts
+++ b/test/TxTypes.test.ts
@@ -50,7 +50,6 @@ describe('TxTypesTest', function () {
     expect(parsed['accountIndex']).to.equal(fullExitNft.accountIndex);
     expect(parsed['nftIndex']).to.equal(fullExitNft.nftIndex);
     expect(parsed['owner']).to.equal(fullExitNft.owner);
-    expect(parsed['creatorAddress']).to.equal(fullExitNft.creatorAddress);
   });
 
   it('ChangePubKey pudata should be deserialized correctly', async function () {

--- a/test/ZkBNB.additional.test.ts
+++ b/test/ZkBNB.additional.test.ts
@@ -355,7 +355,7 @@ describe('ZkBNB', function () {
         it('should can commit fullExitNFT operation', async () => {
           mockNftFactory.ownerOf.returns(zkBNB.address);
 
-          const tx = await zkBNB.requestFullExitNft(0, zkBNB.signer.address, nftL1TokenId, 0);
+          const tx = await zkBNB.requestFullExitNft(0, nftL1TokenId);
 
           const receipt = await tx.wait();
           const event = receipt.events.find((event) => {
@@ -394,7 +394,7 @@ describe('ZkBNB', function () {
 
       // Pre-submit a block for every case
       // commit block #1 fullExit nft;
-      let tx = await zkBNB.requestFullExitNft(0, zkBNB.signer.address, nftL1TokenId, 0);
+      let tx = await zkBNB.requestFullExitNft(0, nftL1TokenId);
       let receipt = await tx.wait();
       let event = receipt.events.find((event) => {
         return event.event === 'NewPriorityRequest';


### PR DESCRIPTION
### Description

`creatorAddress` and `nftContentType` should be set by L2 not by contract


Notable changes:
* remove `creatorAddress` and `nftContentType` in `requestFullExitNft`
* fix test cases