### PR TITLE
Fix withdraw and withdrawNft TxTypes

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -616,7 +616,6 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
             creatorTreasuryRate: _tx.creatorTreasuryRate,
             nftIndex: _tx.nftIndex,
             collectionId: _tx.collectionId,
-            gasFeeAccountIndex: 0,
             gasFeeAssetId: 0,
             gasFeeAssetAmount: 0,
             toAddress: _tx.owner,

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -57,8 +57,7 @@ library TxTypes {
     uint32 creatorAccountIndex;
     uint16 creatorTreasuryRate;
     uint40 nftIndex;
-    uint32 collectionId;
-    uint32 gasFeeAccountIndex;
+    uint16 collectionId; // uint16
     uint16 gasFeeAssetId;
     uint16 gasFeeAssetAmount;
     address toAddress;
@@ -262,9 +261,7 @@ library TxTypes {
     // nft index
     (offset, parsed.nftIndex) = Bytes.readUInt40(_data, offset);
     // collection id
-    (offset, parsed.collectionId) = Bytes.readUInt32(_data, offset);
-    // gas fee account index
-    (offset, parsed.gasFeeAccountIndex) = Bytes.readUInt32(_data, offset);
+    (offset, parsed.collectionId) = Bytes.readUInt16(_data, offset);
     // gas fee asset id
     (offset, parsed.gasFeeAssetId) = Bytes.readUInt16(_data, offset);
     // gas fee asset amount
@@ -278,9 +275,9 @@ library TxTypes {
     // nft content type
     (offset, parsed.nftContentType) = Bytes.readUInt8(_data, offset);
 
-    // 1 + 4 + 4 + 2 + 5 + 4 + 4 + 2 + 2 + 20 + 20 + 4 + 1 + x = 121
-    // x = 48
-    offset += 48;
+    // 1 + 4 + 4 + 2 + 5 + 2 + 2 + 2 + 20 + 20 + 32 + 1 + x = 121
+    // x = 26
+    offset += 26;
     require(offset == PACKED_TX_PUBDATA_BYTES, "5N");
     return parsed;
   }

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -240,8 +240,8 @@ library TxTypes {
     (offset, parsed.gasFeeAssetAmount) = Bytes.readUInt16(_data, offset);
 
     // 1 + 4 + 20 + 2 + 16 + 2 + 2 + x = 121
-    // x = 76
-    offset += 76;
+    // x = 74
+    offset += 74;
 
     require(offset == PACKED_TX_PUBDATA_BYTES, "4N");
     return parsed;

--- a/contracts/test-contracts/TxTypesTest.sol
+++ b/contracts/test-contracts/TxTypesTest.sol
@@ -28,6 +28,10 @@ contract TxTypesTest {
     return TxTypes.readWithdrawPubData(_data);
   }
 
+  function testReadWithdrawNftPubData(bytes memory _data) external pure returns (TxTypes.WithdrawNft memory parsed) {
+    return TxTypes.readWithdrawNftPubData(_data);
+  }
+
   function testWriteDepositPubData(TxTypes.Deposit memory _tx) external pure returns (bytes memory buf) {
     return TxTypes.writeDepositPubDataForPriorityQueue(_tx);
   }

--- a/contracts/test-contracts/TxTypesTest.sol
+++ b/contracts/test-contracts/TxTypesTest.sol
@@ -23,4 +23,24 @@ contract TxTypesTest {
   function testReadChangePubKeyPubData(bytes memory _data) external pure returns (TxTypes.ChangePubKey memory parsed) {
     return TxTypes.readChangePubKeyPubData(_data);
   }
+
+  function testReadWithdrawPubData(bytes memory _data) external pure returns (TxTypes.Withdraw memory parsed) {
+    return TxTypes.readWithdrawPubData(_data);
+  }
+
+  function testWriteDepositPubData(TxTypes.Deposit memory _tx) external pure returns (bytes memory buf) {
+    return TxTypes.writeDepositPubDataForPriorityQueue(_tx);
+  }
+
+  function testReadDepositPubData(bytes memory _data) external pure returns (TxTypes.Deposit memory parsed) {
+    return TxTypes.readDepositPubData(_data);
+  }
+
+  function testWriteDepositNftPubData(TxTypes.DepositNft memory _tx) external pure returns (bytes memory buf) {
+    return TxTypes.writeDepositNftPubDataForPriorityQueue(_tx);
+  }
+
+  function testReadDepositNftPubData(bytes memory _data) external pure returns (TxTypes.DepositNft memory parsed) {
+    return TxTypes.readDepositNftPubData(_data);
+  }
 }

--- a/test/TxTypes.test.ts
+++ b/test/TxTypes.test.ts
@@ -66,4 +66,61 @@ describe('TxTypesTest', function () {
     expect(parsed['owner']).to.equal('0xB64d00616958131824B472CC20C3d47Bb5d9926C');
     expect(parsed['nonce']).to.equal(0);
   });
+
+  it('Withdraw pubdata should be read correctly', async function () {
+    const rawPubdata =
+      '05000000038b2c5a5744f42aa9269baabdd05933a96d8ef9110000000000000000000000000000000000640000fa0a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+
+    const bytes = ethers.utils.arrayify('0x' + rawPubdata);
+    const pubdata = await this.bytesTest.sliceBytes(bytes, 0, 121);
+    const parsed = await this.txTypesTest.testReadWithdrawPubData(pubdata);
+
+    expect(parsed['accountIndex']).to.equal(3);
+    expect(parsed['toAddress']).to.equal('0x8b2C5A5744F42AA9269BaabDd05933a96D8EF911');
+    expect(parsed['assetId']).to.equal(0);
+    expect(parsed['assetAmount']).to.equal(ethers.BigNumber.from('100'));
+    expect(parsed['gasFeeAssetId']).to.equal(0);
+    expect(parsed['gasFeeAssetAmount']).to.equal(64010);
+  });
+
+  it('Deposit pubdata should be read correctly', async function () {
+    const deposit = {
+      txType: 2,
+      accountIndex: 1,
+      toAddress: acc1.address,
+      assetId: 6,
+      amount: 50,
+    };
+    const encoded = await this.txTypesTest.testWriteDepositPubData(deposit);
+    const parsed = await this.txTypesTest.testReadDepositPubData(encoded);
+
+    expect(parsed['toAddress']).to.equal(acc1.address);
+    expect(parsed['assetId']).to.equal(deposit.assetId);
+    expect(parsed['amount']).to.equal(deposit.amount);
+  });
+
+  it('DepositNft pubdata should be read correctly', async function () {
+    const depositNft = {
+      txType: 3,
+      accountIndex: 4,
+      creatorAccountIndex: 5,
+      creatorTreasuryRate: 20,
+      nftIndex: 111,
+      collectionId: 222,
+      owner: owner.address,
+      nftContentHash: ethers.utils.randomBytes(32),
+      nftContentType: 1,
+    };
+
+    const encoded = await this.txTypesTest.testWriteDepositNftPubData(depositNft);
+    const parsed = await this.txTypesTest.testReadDepositNftPubData(encoded);
+
+    expect(parsed['creatorAccountIndex']).to.equal(depositNft.creatorAccountIndex);
+    expect(parsed['creatorTreasuryRate']).to.equal(depositNft.creatorTreasuryRate);
+    expect(parsed['nftIndex']).to.equal(depositNft.nftIndex);
+    expect(parsed['collectionId']).to.equal(depositNft.collectionId);
+    expect(parsed['owner']).to.equal(depositNft.owner);
+    expect(parsed['nftContentHash']).to.equal(ethers.utils.hexlify(depositNft.nftContentHash));
+    expect(parsed['nftContentType']).to.equal(depositNft.nftContentType);
+  });
 });

--- a/test/TxTypes.test.ts
+++ b/test/TxTypes.test.ts
@@ -80,7 +80,28 @@ describe('TxTypesTest', function () {
     expect(parsed['assetId']).to.equal(0);
     expect(parsed['assetAmount']).to.equal(ethers.BigNumber.from('100'));
     expect(parsed['gasFeeAssetId']).to.equal(0);
-    expect(parsed['gasFeeAssetAmount']).to.equal(64010);
+    expect(parsed['gasFeeAssetAmount']).to.equal(64010); // Fix overflow; actual value is 20000000000000 in L2
+  });
+
+  it('WithdrawNft pubdata should be read correctly', async function () {
+    const rawPubdata =
+      '0b00000002000000020000000000000100000000fa0ad757c6bdb5837d721b04de87c155dba72c9b076cb64d00616958131824b472cc20c3d47bb5d9926c26c21ba5c313610ad92bc967d374d7dbd3ce083e38a403b6f58a9498753a0a32000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+
+    const bytes = ethers.utils.arrayify('0x' + rawPubdata);
+    const pubdata = await this.bytesTest.sliceBytes(bytes, 0, 121);
+    const parsed = await this.txTypesTest.testReadWithdrawNftPubData(pubdata);
+
+    expect(parsed['accountIndex']).to.equal(2);
+    expect(parsed['creatorAccountIndex']).to.equal(2);
+    expect(parsed['creatorTreasuryRate']).to.equal(0);
+    expect(parsed['nftIndex']).to.equal(1);
+    expect(parsed['collectionId']).to.equal(0);
+    expect(parsed['gasFeeAssetId']).to.equal(0);
+    expect(parsed['gasFeeAssetAmount']).to.equal(64010); // Fix overflow; actual value is 20000000000000 in L2
+    expect(parsed['toAddress']).to.equal('0xd757C6bDb5837d721B04DE87c155DBa72c9B076C');
+    expect(parsed['creatorAddress']).to.equal('0xB64d00616958131824B472CC20C3d47Bb5d9926C');
+    expect(parsed['nftContentHash']).to.equal('0x26c21ba5c313610ad92bc967d374d7dbd3ce083e38a403b6f58a9498753a0a32');
+    expect(parsed['nftContentType']).to.equal(0);
   });
 
   it('Deposit pubdata should be read correctly', async function () {

--- a/test/nft/ZkBNB.nft.test.ts
+++ b/test/nft/ZkBNB.nft.test.ts
@@ -167,7 +167,6 @@ describe('NFT functionality', function () {
         creatorTreasuryRate: 5,
         nftIndex,
         collectionId: 0,
-        gasFeeAccountIndex: 1,
         gasFeeAssetId: 0, //BNB
         gasFeeAssetAmount: 666,
         toAddress: acc2.address,
@@ -188,7 +187,6 @@ describe('NFT functionality', function () {
         creatorTreasuryRate: result['creatorTreasuryRate'],
         nftIndex: result['nftIndex'],
         collectionId: result['collectionId'],
-        gasFeeAccountIndex: result['gasFeeAccountIndex'],
         gasFeeAssetId: result['gasFeeAssetId'],
         gasFeeAssetAmount: result['gasFeeAssetAmount'],
         toAddress: result['toAddress'],


### PR DESCRIPTION
### Description

- Remove gasFeeAccount from withdraw nft
- Changed collectionId from uint32 to uint16
- Fixed a wrong offset in withdraw pudata
- Added more test case for pudate ser/deser