### PR TITLE
remove unused fields in TxTypes and ignore them at serialization

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -591,8 +591,6 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
             creatorTreasuryRate: _tx.creatorTreasuryRate,
             nftIndex: _tx.nftIndex,
             collectionId: _tx.collectionId,
-            gasFeeAssetId: 0,
-            gasFeeAssetAmount: 0,
             toAddress: _tx.owner,
             creatorAddress: _tx.creatorAddress,
             nftContentHash: _tx.nftContentHash,

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -47,8 +47,8 @@ library TxTypes {
     address toAddress;
     uint16 assetId;
     uint128 assetAmount;
-    uint16 gasFeeAssetId;
-    uint16 gasFeeAssetAmount;
+    // uint16 gasFeeAssetId; -- present in pubdata, ignored at serialization
+    // uint16 gasFeeAssetAmount; -- present in pubdata, ignored at serialization
   }
 
   // Withdraw Nft pubdata
@@ -57,9 +57,9 @@ library TxTypes {
     uint32 creatorAccountIndex;
     uint16 creatorTreasuryRate;
     uint40 nftIndex;
-    uint16 collectionId; // uint16
-    uint16 gasFeeAssetId;
-    uint16 gasFeeAssetAmount;
+    uint16 collectionId;
+    // uint16 gasFeeAssetId; -- present in pubdata, ignored at serialization
+    // uint16 gasFeeAssetAmount; -- present in pubdata, ignored at serialization
     address toAddress;
     address creatorAddress; // creatorAccountNameHash => creatorAddress
     bytes32 nftContentHash;
@@ -234,13 +234,13 @@ library TxTypes {
     // amount
     (offset, parsed.assetAmount) = Bytes.readUInt128(_data, offset);
     // gas fee asset id
-    (offset, parsed.gasFeeAssetId) = Bytes.readUInt16(_data, offset);
+    // (offset, parsed.gasFeeAssetId) = Bytes.readUInt16(_data, offset);
     // gas fee asset amount
-    (offset, parsed.gasFeeAssetAmount) = Bytes.readUInt16(_data, offset);
+    // (offset, parsed.gasFeeAssetAmount) = Bytes.readUInt16(_data, offset);
 
-    // 1 + 4 + 20 + 2 + 16 + 2 + 2 + x = 121
-    // x = 74
-    offset += 74;
+    // 1 + 4 + 20 + 2 + 16 + x = 121
+    // x = 78
+    offset += 78;
 
     require(offset == PACKED_TX_PUBDATA_BYTES, "4N");
     return parsed;
@@ -263,9 +263,11 @@ library TxTypes {
     // collection id
     (offset, parsed.collectionId) = Bytes.readUInt16(_data, offset);
     // gas fee asset id
-    (offset, parsed.gasFeeAssetId) = Bytes.readUInt16(_data, offset);
+    // (offset, parsed.gasFeeAssetId) = Bytes.readUInt16(_data, offset);
     // gas fee asset amount
-    (offset, parsed.gasFeeAssetAmount) = Bytes.readUInt16(_data, offset);
+    // (offset, parsed.gasFeeAssetAmount) = Bytes.readUInt16(_data, offset);
+    offset += 4;
+
     // withdraw to L1 address
     (offset, parsed.toAddress) = Bytes.readAddress(_data, offset);
     // creator address

--- a/test/TxTypes.test.ts
+++ b/test/TxTypes.test.ts
@@ -79,8 +79,6 @@ describe('TxTypesTest', function () {
     expect(parsed['toAddress']).to.equal('0x8b2C5A5744F42AA9269BaabDd05933a96D8EF911');
     expect(parsed['assetId']).to.equal(0);
     expect(parsed['assetAmount']).to.equal(ethers.BigNumber.from('100'));
-    expect(parsed['gasFeeAssetId']).to.equal(0);
-    expect(parsed['gasFeeAssetAmount']).to.equal(64010); // Fix overflow; actual value is 20000000000000 in L2
   });
 
   it('WithdrawNft pubdata should be read correctly', async function () {
@@ -96,8 +94,6 @@ describe('TxTypesTest', function () {
     expect(parsed['creatorTreasuryRate']).to.equal(0);
     expect(parsed['nftIndex']).to.equal(1);
     expect(parsed['collectionId']).to.equal(0);
-    expect(parsed['gasFeeAssetId']).to.equal(0);
-    expect(parsed['gasFeeAssetAmount']).to.equal(64010); // Fix overflow; actual value is 20000000000000 in L2
     expect(parsed['toAddress']).to.equal('0xd757C6bDb5837d721B04DE87c155DBa72c9B076C');
     expect(parsed['creatorAddress']).to.equal('0xB64d00616958131824B472CC20C3d47Bb5d9926C');
     expect(parsed['nftContentHash']).to.equal('0x26c21ba5c313610ad92bc967d374d7dbd3ce083e38a403b6f58a9498753a0a32');

--- a/test/nft/ZkBNB.nft.test.ts
+++ b/test/nft/ZkBNB.nft.test.ts
@@ -121,8 +121,6 @@ describe('NFT functionality', function () {
         nftIndex: mockNftIndex,
         collectionId: 0,
         gasFeeAccountIndex: 1,
-        gasFeeAssetId: 0, //BNB
-        gasFeeAssetAmount: 666,
         toAddress: acc1.address,
         creatorAddress: owner.address,
         nftContentHash: mockHash,
@@ -167,8 +165,6 @@ describe('NFT functionality', function () {
         creatorTreasuryRate: 5,
         nftIndex,
         collectionId: 0,
-        gasFeeAssetId: 0, //BNB
-        gasFeeAssetAmount: 666,
         toAddress: acc2.address,
         creatorAddress: owner.address,
         nftContentHash: mockHash,
@@ -187,8 +183,6 @@ describe('NFT functionality', function () {
         creatorTreasuryRate: result['creatorTreasuryRate'],
         nftIndex: result['nftIndex'],
         collectionId: result['collectionId'],
-        gasFeeAssetId: result['gasFeeAssetId'],
-        gasFeeAssetAmount: result['gasFeeAssetAmount'],
         toAddress: result['toAddress'],
         creatorAddress: result['creatorAddress'],
         nftContentHash: result['nftContentHash'],
@@ -253,8 +247,6 @@ describe('NFT functionality', function () {
         nftIndex: mockNftIndex,
         collectionId: 0,
         gasFeeAccountIndex: 1,
-        gasFeeAssetId: 0, //BNB
-        gasFeeAssetAmount: 666,
         toAddress: acc1.address,
         creatorAddress: owner.address,
         nftContentHash: mockHash,
@@ -320,8 +312,6 @@ describe('NFT functionality', function () {
         nftIndex: mockNftIndex,
         collectionId: 0,
         gasFeeAccountIndex: 1,
-        gasFeeAssetId: 0, //BNB
-        gasFeeAssetAmount: 666,
         toAddress: acc1.address,
         creatorAddress: owner.address,
         nftContentHash: mockHash,


### PR DESCRIPTION
### Description

The `gasFeeAssetId` and `gasFeeAssetAmount` fields are present in `Withdraw` and `WithdrawNft` pubdata but neither used nor stored in contract. We need to remove them from struct and skip them at serialization.
