### PR TITLE
fix amount logic in withdrawPendingBalance

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -145,7 +145,7 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
     uint128 balance = pendingBalances[packedBalanceKey].balanceToWithdraw;
     uint128 amount = Utils.minU128(balance, _amount);
     if (_assetId == 0) {
-      (bool success, ) = _owner.call{value: _amount}("");
+      (bool success, ) = _owner.call{value: amount}("");
       // Native Asset withdraw failed
       require(success, "d");
     } else {
@@ -154,8 +154,8 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
       // `value` can be bigger then `_amount` requested if token takes fee from sender in addition to `_amount` requested
       amount = this.transferERC20(IERC20(_token), _owner, amount, balance);
     }
-    pendingBalances[packedBalanceKey].balanceToWithdraw = balance - _amount;
-    emit Withdrawal(_assetId, _amount);
+    pendingBalances[packedBalanceKey].balanceToWithdraw = balance - amount;
+    emit Withdrawal(_assetId, amount);
   }
 
   /// @notice Sends tokens


### PR DESCRIPTION
### Description

fix amount logic in withdrawPendingBalance

### Rationale

input _amount need to compare with balance and use min(_amount, balance) as new amount. old logic didn't use processed `amount`

### Example


### Changes

Notable changes:
* fix amount logic in withdrawPendingBalance