### PR TITLE
check input nftIndex of withdrawPendingNFTBalance

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -126,6 +126,8 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
   /// @param _nftIndex Id of NFT token
   function withdrawPendingNFTBalance(uint40 _nftIndex) external {
     TxTypes.WithdrawNft memory op = pendingWithdrawnNFTs[_nftIndex];
+    // _nftIndex needs to be valid , check op.nftContentHash in order to check op is not null
+    require(op.nftContentHash != bytes32(0), "6H");
     withdrawOrStoreNFT(op);
     delete pendingWithdrawnNFTs[_nftIndex];
   }

--- a/test/nft/ZkBNB.nft.test.ts
+++ b/test/nft/ZkBNB.nft.test.ts
@@ -231,6 +231,10 @@ describe('NFT functionality', function () {
       assert.equal(result['nftContentHash'], 0);
       assert.equal(result['nftIndex'], 0);
     });
+
+    it('Input nftIndex should be valid', async function () {
+      expect(zkBNB.withdrawPendingNFTBalance(9999)).to.be.revertedWith('6H');
+    });
   });
 
   describe('deposit NFT', async function () {


### PR DESCRIPTION
### Description

withdrawPendingNFTBalance can be call by anyone, user may input an invalid nftIndex
check op.nftContentHash in order to check op is not null

### Rationale

if input nftIndex is invalid ,  pendingWithdrawnNFTs[_nftIndex] will be null and affect other logic

### Example


### Changes

Notable changes:
* check op.nftContentHash not null