### PR TITLE
add flags for deserted nfts and don't check msg.sender in performdesert

### DIFF
--- a/contracts/DesertVerifier.sol
+++ b/contracts/DesertVerifier.sol
@@ -26,9 +26,9 @@ contract DesertVerifier {
   struct NftExitData {
     uint40 nftIndex;
     uint ownerAccountIndex;
-    uint creatorAccountIndex;
-    uint creatorTreasuryRate;
-    uint collectionId;
+    uint32 creatorAccountIndex;
+    uint16 creatorTreasuryRate;
+    uint16 collectionId;
     bytes16 nftContentHash1;
     bytes16 nftContentHash2;
     uint8 nftContentType;
@@ -40,6 +40,7 @@ contract DesertVerifier {
     poseidonT7 = IPoseidonT7(_poseidonT7);
   }
 
+  /// @notice verify ownership of assets
   function verifyExitProofBalance(
     uint256 stateRoot,
     uint256 nftRoot,
@@ -68,6 +69,8 @@ contract DesertVerifier {
     return (hashNode(accountRoot, nftRoot) == stateRoot);
   }
 
+  /// @notice verify ownership of nfts
+  /// @param accountData the owner of nfts, accountId must match nft's ownerAccountIndex
   function verifyExitNftProof(
     uint256 stateRoot,
     uint256 assetRoot,

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -95,8 +95,10 @@ contract Storage {
   /// @dev Once it was raised, it can not be cleared again, and all users must exit
   bool public desertMode;
 
-  /// @dev Flag indicates that a user has exited in the desert mode certain token balance (per account id and tokenId)
+  /// @dev Flag indicates that a user has exited certain token balance in the desert mode (per account id and tokenId)
   mapping(uint32 => mapping(uint32 => bool)) internal performedDesert;
+  /// @dev Flag indicates that a nft has been exited in the desert mode
+  mapping(uint40 => bool) internal performedDesertNfts;
 
   /// @notice Checks that current state not is desert mode
   modifier onlyActive() {

--- a/contracts/interfaces/Events.sol
+++ b/contracts/interfaces/Events.sol
@@ -15,6 +15,9 @@ interface Events {
   /// @notice Event emitted when user funds are withdrawn from the ZkBNB state and contract
   event Withdrawal(uint16 assetId, uint128 amount);
 
+  /// @notice Event emitted when user funds are withdrawn from the ZkBNB state but not from contract
+  event WithdrawalPending(uint16 indexed assetId, address indexed recepient, uint128 amount);
+
   /// @notice Event emitted when user funds are deposited to the zkbnb account
   event Deposit(uint16 assetId, address to, uint128 amount);
 
@@ -75,7 +78,7 @@ interface Events {
   /// @notice NFT withdraw event.
   event WithdrawNft(uint32 accountIndex, address nftL1Address, address toAddress, uint256 nftL1TokenId);
 
-  /// @notice Event emitted when user NFT is withdrawn from the zkSync state but not from contract
+  /// @notice Event emitted when user NFT is withdrawn from the zkBNB state but not from contract
   event WithdrawalNFTPending(uint40 indexed nftIndex);
 }
 

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -228,7 +228,7 @@ async function deployDesertVerifier(owner) {
   const poseidonT7 = await PoseidonT7.deploy();
   await poseidonT7.deployed();
 
-  const DesertVerifier = await ethers.getContractFactory('DesertVerifierTest');
+  const DesertVerifier = await ethers.getContractFactory('DesertVerifier');
   const desertVerifier = await DesertVerifier.deploy(poseidonT3.address, poseidonT6.address, poseidonT7.address);
   await desertVerifier.deployed();
 


### PR DESCRIPTION
### Description

bug fixes and some code optimization

### Changes

Notable changes:
* added flags for deserted nfts to avoid double-desert
* remove checking for `msg.sender` in both `performDesert` and `performDesertNft`
* change exit data types to avoid type casting