### PR TITLE
change tokenURI from string to struct

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -536,6 +536,10 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
     return pendingBalances[packAddressAndAssetId(_address, assetId)].balanceToWithdraw;
   }
 
+  function getNftTokenURI(uint8 nftContentType, bytes32 nftContentHash) external view returns (string memory tokenURI) {
+    return governance.getNftTokenURI(nftContentType, nftContentHash);
+  }
+
   function withdrawOrStoreNFT(TxTypes.WithdrawNft memory op) internal {
     require(op.nftIndex <= MAX_NFT_INDEX, "invalid nft index");
 
@@ -562,13 +566,7 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
         storePendingNFT(op);
       }
     } else {
-      try
-        INFTFactory(_factoryAddress).mintFromZkBNB(
-          op.toAddress,
-          op.nftIndex,
-          governance.getNftTokenURI(op.nftContentType, op.nftContentHash)
-        )
-      {
+      try INFTFactory(_factoryAddress).mintFromZkBNB(op.toAddress, op.nftContentType, op.nftIndex, op.nftContentHash) {
         // register default collection factory
         governance.registerDefaultNFTFactory(op.creatorAddress, op.collectionId);
 

--- a/contracts/ZkBNBNFTFactory.sol
+++ b/contracts/ZkBNBNFTFactory.sol
@@ -1,14 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./interfaces/INFTFactory.sol";
 import "./lib/Bytes.sol";
 import "./lib/Ownable2Step.sol";
 
-contract ZkBNBNFTFactory is ERC721URIStorage, INFTFactory, Ownable2Step, ReentrancyGuard {
+interface IZkBNB {
+  function getNftTokenURI(uint8 nftContentType, bytes32 nftContentHash) external view returns (string memory tokenURI);
+}
+
+contract ZkBNBNFTFactory is ERC721, INFTFactory, Ownable2Step, ReentrancyGuard {
   address private _zkbnbAddress;
+
+  struct NftContentURI {
+    uint8 nftContentType;
+    bytes32 nftContentHash;
+  }
+
+  mapping(uint256 => NftContentURI) private _uris;
 
   constructor(
     string memory name,
@@ -19,10 +30,22 @@ contract ZkBNBNFTFactory is ERC721URIStorage, INFTFactory, Ownable2Step, Reentra
     _zkbnbAddress = zkbnbAddress;
   }
 
-  function mintFromZkBNB(address _toAddress, uint256 _nftTokenId, string memory _nftTokenURI) external nonReentrant {
+  function mintFromZkBNB(
+    address _toAddress,
+    uint8 _nftContentType,
+    uint256 _nftTokenId,
+    bytes32 _nftContentHash
+  ) external nonReentrant {
     require(_msgSender() == _zkbnbAddress, "only zkbnbAddress");
     // Minting allowed only from zkbnb
-    _safeMint(_toAddress, _nftTokenId);
-    _setTokenURI(_nftTokenId, _nftTokenURI);
+    _safeMint(_toAddress, _nftTokenId, "");
+    // set tokenURI
+    _uris[_nftTokenId] = NftContentURI({nftContentType: _nftContentType, nftContentHash: _nftContentHash});
+  }
+
+  function tokenURI(uint256 tokenId) public view override returns (string memory) {
+    _requireMinted(tokenId);
+    NftContentURI memory uri = _uris[tokenId];
+    return IZkBNB(_zkbnbAddress).getNftTokenURI(uri.nftContentType, uri.nftContentHash);
   }
 }

--- a/contracts/interfaces/INFTFactory.sol
+++ b/contracts/interfaces/INFTFactory.sol
@@ -3,18 +3,10 @@
 pragma solidity ^0.8.0;
 
 interface INFTFactory {
-  // event MintNFTFromZkBNB(
-  //   address indexed _creatorAddress,
-  //   address indexed _toAddress,
-  //   uint256 _nftTokenId,
-  //   bytes _extraData
-  // );
-
   function mintFromZkBNB(
-    // address _creatorAddress,
     address _toAddress,
+    uint8 _nftContentType,
     uint256 _nftTokenId,
-    string memory _nftTokenURI
-    // bytes memory _extraData
+    bytes32 _nftContentHash
   ) external;
 }

--- a/contracts/test-contracts/ZkBNBTest.sol
+++ b/contracts/test-contracts/ZkBNBTest.sol
@@ -74,9 +74,10 @@ contract ZkBNBTest is ZkBNB {
   function mintNFT(
     address defaultNFTFactory,
     address _toAddress,
+    uint8 _nftContentType,
     uint256 _nftTokenId,
-    string memory _nftTokenURI
+    bytes32 _nftContentHash
   ) external {
-    return INFTFactory(defaultNFTFactory).mintFromZkBNB(_toAddress, _nftTokenId, _nftTokenURI);
+    return INFTFactory(defaultNFTFactory).mintFromZkBNB(_toAddress, _nftContentType, _nftTokenId, _nftContentHash);
   }
 }

--- a/test/nft/ZkBNB.nft.test.ts
+++ b/test/nft/ZkBNB.nft.test.ts
@@ -379,8 +379,10 @@ describe('NFT functionality', function () {
       const tokenURI = await governance.getNftTokenURI(0, IPFSMultiHashDigest);
       // const extraData = ethers.constants.HashZero;
 
-      expect(zkBNBNFTFactory.mintFromZkBNB(acc2.address, tokenId, tokenURI)).to.be.revertedWith('only zkbnbAddress');
-      await expect(await zkBNB.mintNFT(zkBNBNFTFactory.address, acc2.address, tokenId, tokenURI));
+      expect(zkBNBNFTFactory.mintFromZkBNB(acc2.address, 0, tokenId, IPFSMultiHashDigest)).to.be.revertedWith(
+        'only zkbnbAddress',
+      );
+      await expect(await zkBNB.mintNFT(zkBNBNFTFactory.address, acc2.address, 0, tokenId, IPFSMultiHashDigest));
       // remove emit event of MintNFTFromZkBNB
       // .to.emit(zkBNBNFTFactory, 'MintNFTFromZkBNB')
       // .withArgs(acc1.address, acc2.address, tokenId, extraData);


### PR DESCRIPTION
### Description

change tokenURI from string to 

``
struct NftContentURI {
    uint8 nftContentType;
    bytes32 nftContentHash;
  }
``

### Rationale

tokenURI string storage cost a lot of gas, change to that pattern can reduce gas usage when mint NFT.

### Example

### Changes

Notable changes:
* add a struct NftContentURI in ZkBNBNFTFactory.sol
* add a mapping to store NftContentURI in ZkBNBNFTFactory.sol
* change ZkBNBNFTFactory from ERC721Storage to ERC721
* change setTokenURI to save NftContentURI in a mapping in ZkBNBNFTFactory.sol
* add a getNftTokenURI view function in ZkBNB.sol to call governance to get full tokenURI string.
* add a interface IZkBNB  in ZkBNBNFTFactory.sol  to call zkbnb.
* change _safeMint(_toAddress, _nftTokenId) to _safeMint(_toAddress, _nftTokenId,"") to reduce call depth. in ZkBNBNFTFactory.sol . This can save gas.