### PR TITLE
Check totalOpenPriorityRequests is zero or not in activateDesertMode

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -62,7 +62,8 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
     // #else
     trigger =
       block.number >= priorityRequests[firstPriorityRequestId].expirationBlock &&
-      priorityRequests[firstPriorityRequestId].expirationBlock != 0;
+      priorityRequests[firstPriorityRequestId].expirationBlock != 0 &&
+      totalOpenPriorityRequests != 0;
     // #endif
     if (trigger) {
       if (!desertMode) {


### PR DESCRIPTION
### Description

desert mode can only be activated if there is unprocessed requests && the oldest unprocessed request expired

### Changes

Notable changes:
* added check for `totalOpenPriorityRequest` in activateDesertMode
* added check in unit tests