### PR TITLE
Remove unused poseidon

### DIFF
--- a/contracts/DesertVerifier.sol
+++ b/contracts/DesertVerifier.sol
@@ -5,7 +5,6 @@ import "./interfaces/IPoseidon.sol";
 
 contract DesertVerifier {
   IPoseidonT3 poseidonT3;
-  IPoseidonT6 poseidonT6;
   IPoseidonT7 poseidonT7;
 
   struct AssetExitData {
@@ -34,9 +33,8 @@ contract DesertVerifier {
     uint8 nftContentType;
   }
 
-  constructor(address _poseidonT3, address _poseidonT6, address _poseidonT7) {
+  constructor(address _poseidonT3, address _poseidonT7) {
     poseidonT3 = IPoseidonT3(_poseidonT3);
-    poseidonT6 = IPoseidonT6(_poseidonT6);
     poseidonT7 = IPoseidonT7(_poseidonT7);
   }
 

--- a/contracts/interfaces/IPoseidon.sol
+++ b/contracts/interfaces/IPoseidon.sol
@@ -5,10 +5,6 @@ interface IPoseidonT3 {
   function poseidon(uint256[2] memory input) external pure returns (uint256);
 }
 
-interface IPoseidonT6 {
-  function poseidon(uint256[5] memory input) external pure returns (uint256);
-}
-
 interface IPoseidonT7 {
   function poseidon(uint256[6] memory input) external pure returns (uint256);
 }

--- a/contracts/test-contracts/DesertTest.sol
+++ b/contracts/test-contracts/DesertTest.sol
@@ -4,11 +4,7 @@ pragma solidity ^0.8.0;
 import "../DesertVerifier.sol";
 
 contract DesertVerifierTest is DesertVerifier {
-  constructor(
-    address _poseidonT3,
-    address _poseidonT6,
-    address _poseidonT7
-  ) DesertVerifier(_poseidonT3, _poseidonT6, _poseidonT7) {}
+  constructor(address _poseidonT3, address _poseidonT7) DesertVerifier(_poseidonT3, _poseidonT7) {}
 
   function testGetAssetRoot(
     uint16 assetId,

--- a/contracts/test-contracts/DesertTest.sol
+++ b/contracts/test-contracts/DesertTest.sol
@@ -8,7 +8,7 @@ contract DesertVerifierTest is DesertVerifier {
 
   function testGetAssetRoot(
     uint16 assetId,
-    uint256 amount,
+    uint128 amount,
     uint256 offerCanceledOrFinalized,
     uint256[16] memory assetMerkleProof
   ) external view returns (uint256) {
@@ -42,11 +42,11 @@ contract DesertVerifierTest is DesertVerifier {
     uint40 nftIndex,
     uint8 _nftContentType,
     uint256 ownerAccountIndex,
-    uint256 creatorAccountIndex,
+    uint32 creatorAccountIndex,
     bytes16 nftContentHash1,
     bytes16 nftContentHash2,
-    uint256 creatorTreasuryRate,
-    uint256 collectionId,
+    uint16 creatorTreasuryRate,
+    uint16 collectionId,
     uint256[40] memory nftMerkleProof
   ) external view returns (uint256) {
     return

--- a/scripts/deploy-keccak256/utils.js
+++ b/scripts/deploy-keccak256/utils.js
@@ -46,16 +46,12 @@ exports.deployDesertVerifier = async function (owner) {
   const poseidonT3 = await PoseidonT3.deploy();
   await poseidonT3.deployed();
 
-  const PoseidonT6 = new ethers.ContractFactory(poseidonContract.generateABI(5), poseidonContract.createCode(5), owner);
-  const poseidonT6 = await PoseidonT6.deploy();
-  await poseidonT6.deployed();
-
   const PoseidonT7 = new ethers.ContractFactory(poseidonContract.generateABI(6), poseidonContract.createCode(6), owner);
   const poseidonT7 = await PoseidonT7.deploy();
   await poseidonT7.deployed();
 
   const DesertVerifier = await ethers.getContractFactory('DesertVerifier');
-  const desertVerifier = await DesertVerifier.deploy(poseidonT3.address, poseidonT6.address, poseidonT7.address);
+  const desertVerifier = await DesertVerifier.deploy(poseidonT3.address, poseidonT7.address);
   await desertVerifier.deployed();
 
   return desertVerifier;

--- a/test/desertMode/DesertVerifier.test.ts
+++ b/test/desertMode/DesertVerifier.test.ts
@@ -15,8 +15,6 @@ describe('DesertVerifier', function () {
 
   // poseidon contract with inputs uint256[2]
   let poseidonT3;
-  // poseidon contract with inputs uint256[5]
-  let poseidonT6;
   // poseidon contract with inputs uint256[6]
   let poseidonT7;
   // contract to verify exit proof
@@ -35,14 +33,6 @@ describe('DesertVerifier', function () {
     poseidonT3 = await PoseidonT3.deploy();
     await poseidonT3.deployed();
 
-    const PoseidonT6 = new ethers.ContractFactory(
-      poseidonContract.generateABI(5),
-      poseidonContract.createCode(5),
-      owner,
-    );
-    poseidonT6 = await PoseidonT6.deploy();
-    await poseidonT6.deployed();
-
     const PoseidonT7 = new ethers.ContractFactory(
       poseidonContract.generateABI(6),
       poseidonContract.createCode(6),
@@ -52,7 +42,7 @@ describe('DesertVerifier', function () {
     await poseidonT7.deployed();
 
     const DesertVerifier = await ethers.getContractFactory('DesertVerifierTest');
-    desertVerifier = await DesertVerifier.deploy(poseidonT3.address, poseidonT6.address, poseidonT7.address);
+    desertVerifier = await DesertVerifier.deploy(poseidonT3.address, poseidonT7.address);
     await desertVerifier.deployed();
   });
 


### PR DESCRIPTION
### Description

remove `poseidonT6`  since it's unused

### Changes

Notable changes:
*  removed PoseidonT6 from `DesertVerifier`
*  modified deploy helper function
*  modified related test cases 