### PR TITLE
Remove padding

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -12,5 +12,15 @@
     "max-line-length": ["warn", 80],
     "function-max-lines": "off",
     "code-complexity": ["warn", 15]
-  }
+  },
+   "overrides":[
+      {
+         "files":[
+            "contracts/test-contracts/*.sol"
+         ],
+         "rules":{
+            "no-console":"off"
+         }
+      }
+   ]
 }

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -295,14 +295,6 @@ contract ZkBNB is Events, Storage, Config, ReentrancyGuardUpgradeable, IERC721Re
       require(_newBlock.timestamp >= _previousBlock.timestamp, "g");
     }
 
-    // padding zero transactions
-    if (_newBlock.publicData.length < _newBlock.blockSize * TxTypes.PACKED_TX_PUBDATA_BYTES) {
-      _newBlock.publicData = bytes.concat(
-        _newBlock.publicData,
-        new bytes(_newBlock.blockSize * TxTypes.PACKED_TX_PUBDATA_BYTES - _newBlock.publicData.length)
-      );
-    }
-
     // Check onchain operations
     (bytes32 pendingOnchainOpsHash, uint64 priorityReqCommitted) = collectOnchainOps(_newBlock);
 

--- a/contracts/test-contracts/BytesTest.sol
+++ b/contracts/test-contracts/BytesTest.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../lib/Bytes.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
+import "hardhat/console.sol";
 
 contract BytesTest {
   function bytes32ToHexString(bytes32 hash) external view returns (string memory) {
@@ -19,5 +20,13 @@ contract BytesTest {
 
   function sliceBytes(bytes memory _bytes, uint256 start, uint256 length) external view returns (bytes memory) {
     return Bytes.slice(_bytes, start, length);
+  }
+
+  function bytesConcate(bytes memory publicData, uint16 blockSize) external view {
+    console.log("padding starts %s", gasleft());
+
+    publicData = bytes.concat(publicData, new bytes(blockSize * 121 - publicData.length));
+
+    console.log("padding ends %s", gasleft());
   }
 }

--- a/test/bytes.test.js
+++ b/test/bytes.test.js
@@ -18,4 +18,15 @@ describe('BytesTest', function () {
     const result = await this.bytesTest.concatStringAndBytes32(prefix, hash);
     expect(result).to.equal(`${prefix}${hash.substring(2)}`);
   });
+
+  it('padding gas test', async function () {
+    const rawPubdata =
+      '04000000038b2c5a5744f42aa9269baabdd05933a96d8ef911000000000000000000000000000000000640000fa0a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+
+    const pubdata = ethers.utils.arrayify('0x' + rawPubdata.repeat(9));
+    const blockSize = 16;
+
+    // block size 16, tx 9
+    const result = await this.bytesTest.bytesConcate(pubdata, blockSize);
+  });
 });


### PR DESCRIPTION
### Description

We found the string concatenation in contract costumes more gas than passing empty pubdata in integration test, thus we remove them.

### Example
Here is an example of the gas cost for padding 7 empty transactions to a block size = 16, real tx = 9 block:

it costs 8384 gas, which is more expensive than the zero-bytes calldata cost 121 * 4 * 7 = 3388
<img width="246" alt="image" src="https://user-images.githubusercontent.com/116326639/232496068-18b1eb01-5294-46af-8bfd-b856a1c0fa93.png">


### Changes

Notable changes:
* removed padding in ZkBNB.sol
* added helper function in BytesTest.sol and its unit test
* added a rule in solhint to allow importing `hardhat/console.sol` to calculate gas