### PR TITLE
More gas optimizations and some warning fixes at compile time

### DIFF
--- a/contracts/AssetGovernance.sol
+++ b/contracts/AssetGovernance.sol
@@ -48,8 +48,7 @@ contract AssetGovernance is ReentrancyGuard {
     address _listingFeeToken,
     uint256 _listingFee,
     uint16 _listingCap,
-    address _treasury,
-    uint32 _treasuryAccountIndex
+    address _treasury
   ) {
     governance = Governance(_governance);
     listingFeeToken = IERC20(_listingFeeToken);

--- a/contracts/DeployFactory.sol
+++ b/contracts/DeployFactory.sol
@@ -82,8 +82,7 @@ contract DeployFactory {
       _contracts.listingToken,
       _additionalParams.listingFee,
       _additionalParams.listingCap,
-      _contracts.governor,
-      0
+      _contracts.governor
     );
     verifier = new Proxy(address(_contracts.verifierTarget), abi.encode());
     AdditionalZkBNB additionalZkBNB = new AdditionalZkBNB();

--- a/contracts/lib/Ownable2Step.sol
+++ b/contracts/lib/Ownable2Step.sol
@@ -14,10 +14,10 @@ contract Ownable2Step is IOwnable2Step {
   event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
   event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-  constructor(address owner) {
-    require(owner != address(0), "Cannot set owner to zero");
+  constructor(address __owner) {
+    require(__owner != address(0), "Cannot set owner to zero");
 
-    _owner = owner;
+    _owner = __owner;
   }
 
   /**

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -53,17 +53,17 @@ library TxTypes {
 
   // Withdraw Nft pubdata
   struct WithdrawNft {
+    uint8 nftContentType; // New added
+    uint16 creatorTreasuryRate;
+    uint16 collectionId;
     uint32 accountIndex;
     uint32 creatorAccountIndex;
-    uint16 creatorTreasuryRate;
     uint40 nftIndex;
-    uint16 collectionId;
     // uint16 gasFeeAssetId; -- present in pubdata, ignored at serialization
     // uint16 gasFeeAssetAmount; -- present in pubdata, ignored at serialization
     address toAddress;
     address creatorAddress; // creatorAccountNameHash => creatorAddress
     bytes32 nftContentHash;
-    uint8 nftContentType; // New added
   }
 
   // full exit pubdata

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -216,7 +216,6 @@ async function main() {
         _listingFee.toString(),
         _listingCap,
         governor,
-        0,
       ],
     ],
     utils: [contractFactories.Utils.address],

--- a/test/Governance/AssetGovernance.test.ts
+++ b/test/Governance/AssetGovernance.test.ts
@@ -33,7 +33,6 @@ describe('AssetGovernance', function () {
       listingFee,
       listingCap,
       treasury,
-      0,
     );
     await assetGovernance.deployed();
 


### PR DESCRIPTION
### Description

Gas cost optimized by re-ordering fields in `WithdrawNft` and fixed some warnings emitted at compile time.

### Example

before reordering `WithdrawNft`: 94,438
<img width="404" alt="image" src="https://user-images.githubusercontent.com/116326639/233345997-686a1177-d0e4-4e01-8e8a-f444e5782287.png">
after reordering `WithdrawNft`: 92,234 (2,204 gas saved per storing pending NFT)
<img width="404" alt="image" src="https://user-images.githubusercontent.com/116326639/233346655-1e0a30fa-0ec5-41fe-beb1-e72ec5fec542.png">


### Changes

Notable changes:
* changed the order of members of `WithdrawNft`
* fixed a warning about shadowed declaration in `Ownable2Step.sol`
* removed `_treasuryAccountIndex` from the constructor of `AssetGovernance`