### PR TITLE
fix: decode deploy log in deploy script

### DIFF
--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -88,11 +88,12 @@ async function main() {
   ]);
   // The specified index is the required event.
   // console.log(deployFactoryTxReceipt.logs);
-  const event = AddressesInterface.decodeEventLog(
-    'Addresses',
-    deployFactoryTxReceipt.logs[6].data,
-    deployFactoryTxReceipt.logs[6].topics,
-  );
+  let event;
+  for (const _log of deployFactoryTxReceipt.logs) {
+    if (_log.topics[0] == '0xa6713bbaa2d52898013d0b2731295761eeb112eeb1805178987e2490c1a99998') {
+      event = AddressesInterface.decodeEventLog('Addresses', _log.data, _log.topics);
+    }
+  }
   const [
     governanceEntryAddress,
     assetGovernanceEntryAddress,


### PR DESCRIPTION
### Description

fix: decode deploy log in deploy script

### Rationale

old version get log `deployFactoryTxReceipt.logs[6]`, but Addresses event location changes

### Example

### Changes

Notable changes:
* get `Addresses event` from logs by topic name hash