### PR TITLE
fix: disallow deposit to zero address

### DIFF
--- a/contracts/AdditionalZkBNB.sol
+++ b/contracts/AdditionalZkBNB.sol
@@ -182,11 +182,15 @@ contract AdditionalZkBNB is Storage, Config, Events {
   /// @param _to the receiver L1 address
   function depositBNB(address _to) external payable {
     require(msg.value != 0, "ia");
+    require(_to != address(0), "ib");
+
     registerDeposit(0, SafeCast.toUint128(msg.value), _to);
   }
 
   /// @notice Deposit NFT to Layer 2, BEP721 is supported
   function depositNft(address _to, address _nftL1Address, uint256 _nftL1TokenId) external {
+    require(_to != address(0), "ib");
+
     // check if the nft is mint from layer-2
     bytes32 nftKey = keccak256(abi.encode(_nftL1Address, _nftL1TokenId));
     require(mintedNfts[nftKey].nftContentHash != bytes32(0), "l1 nft is not allowed");
@@ -234,6 +238,7 @@ contract AdditionalZkBNB is Storage, Config, Events {
   /// @param _amount Token amount
   /// @param _to the receiver L1 address
   function depositBEP20(IERC20 _token, uint104 _amount, address _to) external {
+    require(_to != address(0), "ib");
     require(_amount != 0, "I");
     // Get asset id by its address
     uint16 assetId = governance.validateAssetAddress(address(_token));

--- a/test/nft/ZkBNB.nft.test.ts
+++ b/test/nft/ZkBNB.nft.test.ts
@@ -295,6 +295,13 @@ describe('NFT functionality', function () {
       assert.equal(_txType, 3);
     });
 
+    it('should revert if deposit a NFT to zero address', async function () {
+      const mock721 = await smock.fake('ZkBNBRelatedERC721');
+      mock721.ownerOf.returns(zkBNB.address);
+
+      expect(zkBNB.depositNft('_accountName', ethers.constants.AddressZero, '2')).to.be.revertedWith('ib');
+    });
+
     it('should fail to deposit a NFT which is not created by layer2', async function () {
       const mock721 = await smock.fake('ZkBNBRelatedERC721');
       mock721.ownerOf.returns(zkBNB.address);

--- a/test/zkBNB.deposit.test.js
+++ b/test/zkBNB.deposit.test.js
@@ -67,6 +67,10 @@ describe('ZkBNB', function () {
         await expect(zkBNB.depositBNB(toAddress, { value: 0 })).to.be.revertedWith('ia');
       });
 
+      it('should reverted if toAddress is zero address', async () => {
+        await expect(zkBNB.depositBNB(ethers.constants.AddressZero, { value: 100 })).to.be.revertedWith('ib');
+      });
+
       it('should increase totalOpenPriorityRequests', async () => {
         const totalBefore = await zkBNB.totalOpenPriorityRequests();
         await zkBNB.depositBNB(toAddress, { value: 10 });
@@ -110,6 +114,9 @@ describe('ZkBNB', function () {
         mockERC20.balanceOf.returnsAtCall(1, 100);
 
         await expect(zkBNB.depositBEP20(mockERC20.address, 10, toAddress)).to.be.revertedWith('D');
+
+        // toAddress should not be zero address
+        await expect(zkBNB.depositBEP20(mockERC20.address, 10, ethers.constants.AddressZero)).to.be.revertedWith('ib');
       });
 
       it('should transfer erc20', async () => {


### PR DESCRIPTION
### Description

disallow deposit BNB/token/NFT to zero address since it's unable to withdraw to zero address.

