### PR TITLE
fix: remove nonReentrant check for transferERC20

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -239,7 +239,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
     address _to,
     uint128 _amount,
     uint128 _maxAmount
-  ) external nonReentrant returns (uint128 withdrawnAmount) {
+  ) external returns (uint128 withdrawnAmount) {
     require(msg.sender == address(this), "5");
     // can be called only from this contract as one "external" call (to revert all this function state changes if it is needed)
 


### PR DESCRIPTION
### Description

remove nonReentrant check for transferERC20

### Rationale

it will course nonReentrant error when withdraw ERC20 token

### Example

add an example CLI or API response...

### Changes

Notable changes:
* remove nonReentrant check for transferERC20