### PR TITLE
BO-2431 fix: zkbnb selfdestruct

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -44,6 +44,61 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
   // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md
   bytes32 private constant EMPTY_STRING_KECCAK = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
 
+  address private immutable zkbnbImplementation;
+
+  constructor() {
+    zkbnbImplementation = address(this);
+  }
+
+  /// @notice ZkBNB contract initialization. Can be external because Proxy contract intercepts illegal calls of this function.
+  /// @param initializationParameters Encoded representation of initialization parameters:
+  /// @dev _governanceAddress The address of Governance contract
+  /// @dev _verifierAddress The address of Verifier contract
+  /// @dev _genesisStateHash Genesis blocks (first block) state tree root hash
+  function initialize(bytes calldata initializationParameters) external initializer {
+    __ReentrancyGuard_init();
+
+    (
+      address _governanceAddress,
+      address _verifierAddress,
+      address _additionalZkBNB,
+      address _desertVerifier,
+      bytes32 _genesisStateRoot
+    ) = abi.decode(initializationParameters, (address, address, address, address, bytes32));
+
+    verifier = ZkBNBVerifier(_verifierAddress);
+    governance = Governance(_governanceAddress);
+    additionalZkBNB = AdditionalZkBNB(_additionalZkBNB);
+    desertVerifier = DesertVerifier(_desertVerifier);
+
+    StoredBlockInfo memory zeroStoredBlockInfo = StoredBlockInfo(
+      0,
+      0,
+      0,
+      EMPTY_STRING_KECCAK,
+      0,
+      _genesisStateRoot,
+      bytes32(0)
+    );
+    stateRoot = _genesisStateRoot;
+    storedBlockHashes[0] = hashStoredBlockInfo(zeroStoredBlockInfo);
+  }
+
+  /// @notice ZkBNB contract upgrade. Can be external because Proxy contract intercepts illegal calls of this function.
+  /// @param upgradeParameters Encoded representation of upgrade parameters
+  // solhint-disable-next-line no-empty-blocks
+  function upgrade(bytes calldata upgradeParameters) external nonReentrant {
+    (address _additionalZkBNB, address _desertVerifier) = abi.decode(upgradeParameters, (address, address));
+
+    if (_additionalZkBNB != address(0)) {
+      additionalZkBNB = AdditionalZkBNB(_additionalZkBNB);
+    }
+
+    if (_desertVerifier != address(0)) {
+      desertVerifier = DesertVerifier(_desertVerifier);
+    }
+  }
+
   function onERC721Received(
     address operator,
     address from,
@@ -103,55 +158,6 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
   function cancelOutstandingDepositsForDesertMode(uint64 _n, bytes[] memory _depositsPubData) external {
     /// All functions delegated to additional should NOT be nonReentrant
     delegateAdditional();
-  }
-
-  /// @notice ZkBNB contract initialization. Can be external because Proxy contract intercepts illegal calls of this function.
-  /// @param initializationParameters Encoded representation of initialization parameters:
-  /// @dev _governanceAddress The address of Governance contract
-  /// @dev _verifierAddress The address of Verifier contract
-  /// @dev _genesisStateHash Genesis blocks (first block) state tree root hash
-  function initialize(bytes calldata initializationParameters) external initializer {
-    __ReentrancyGuard_init();
-
-    (
-      address _governanceAddress,
-      address _verifierAddress,
-      address _additionalZkBNB,
-      address _desertVerifier,
-      bytes32 _genesisStateRoot
-    ) = abi.decode(initializationParameters, (address, address, address, address, bytes32));
-
-    verifier = ZkBNBVerifier(_verifierAddress);
-    governance = Governance(_governanceAddress);
-    additionalZkBNB = AdditionalZkBNB(_additionalZkBNB);
-    desertVerifier = DesertVerifier(_desertVerifier);
-
-    StoredBlockInfo memory zeroStoredBlockInfo = StoredBlockInfo(
-      0,
-      0,
-      0,
-      EMPTY_STRING_KECCAK,
-      0,
-      _genesisStateRoot,
-      bytes32(0)
-    );
-    stateRoot = _genesisStateRoot;
-    storedBlockHashes[0] = hashStoredBlockInfo(zeroStoredBlockInfo);
-  }
-
-  /// @notice ZkBNB contract upgrade. Can be external because Proxy contract intercepts illegal calls of this function.
-  /// @param upgradeParameters Encoded representation of upgrade parameters
-  // solhint-disable-next-line no-empty-blocks
-  function upgrade(bytes calldata upgradeParameters) external nonReentrant {
-    (address _additionalZkBNB, address _desertVerifier) = abi.decode(upgradeParameters, (address, address));
-
-    if (_additionalZkBNB != address(0)) {
-      additionalZkBNB = AdditionalZkBNB(_additionalZkBNB);
-    }
-
-    if (_desertVerifier != address(0)) {
-      desertVerifier = DesertVerifier(_desertVerifier);
-    }
   }
 
   /// @notice Deposit Native Assets to Layer 2 - transfer BNB from user into contract, validate it, register deposit
@@ -683,6 +689,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
   /// @notice Should be only use to delegate the external calls as it passes the calldata
   /// @notice All functions delegated to additional contract should NOT be nonReentrant
   function delegateAdditional() internal {
+    require(address(this) != zkbnbImplementation, "Can not dirctly call by zkbnbImplementation");
     address _target = address(additionalZkBNB);
     assembly {
       // The pointer to the free memory slot

--- a/contracts/test-contracts/ZkBNBTest.sol
+++ b/contracts/test-contracts/ZkBNBTest.sol
@@ -8,12 +8,19 @@ import "../Storage.sol";
 import "../Config.sol";
 
 contract ZkBNBTest is ZkBNB {
+  address private immutable zkbnbImplementation;
+
+  constructor() {
+    zkbnbImplementation = address(this);
+  }
+
   /// @notice Same as fallback but called when calldata is empty
   receive() external payable {
     _fallback();
   }
 
   function _fallback() internal {
+    require(address(this) != zkbnbImplementation, "Can not dirctly call by zkbnbImplementation");
     address _target = address(additionalZkBNB);
     assembly {
       // The pointer to the free memory slot

--- a/test/ZkBNB.additional.test.ts
+++ b/test/ZkBNB.additional.test.ts
@@ -72,8 +72,8 @@ describe('ZkBNB', function () {
         Utils: utils.address,
       },
     });
-    zkBNB = await ZkBNB.deploy();
-    await zkBNB.deployed();
+    const zkBNBTestImpl = await ZkBNB.deploy();
+    await zkBNBTestImpl.deployed();
 
     const initParams = ethers.utils.defaultAbiCoder.encode(
       ['address', 'address', 'address', 'address', 'bytes32'],
@@ -85,7 +85,12 @@ describe('ZkBNB', function () {
         genesisStateRoot,
       ],
     );
-    await zkBNB.initialize(initParams);
+    await zkBNBTestImpl.initialize(initParams);
+
+    const Proxy = await ethers.getContractFactory('Proxy');
+    const zkBNBProxy = await Proxy.deploy(zkBNBTestImpl.address, initParams);
+    await zkBNBProxy.deployed();
+    zkBNB = await ZkBNB.attach(zkBNBProxy.address);
 
     // mock functions
     mockGovernance.getNFTFactory.returns(mockNftFactory.address);

--- a/test/ZkBNBRelatedERC20.test.ts
+++ b/test/ZkBNBRelatedERC20.test.ts
@@ -41,8 +41,8 @@ describe('ZkBNBRelatedERC20', async function () {
         Utils: utils.address,
       },
     });
-    zkBNB = await ZkBNB.deploy();
-    await zkBNB.deployed();
+    const zkBNBImpl = await ZkBNB.deploy();
+    await zkBNBImpl.deployed();
 
     const initParams = ethers.utils.defaultAbiCoder.encode(
       ['address', 'address', 'address', 'address', 'bytes32'],
@@ -54,7 +54,12 @@ describe('ZkBNBRelatedERC20', async function () {
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       ],
     );
-    await zkBNB.initialize(initParams);
+    await zkBNBImpl.initialize(initParams);
+
+    const Proxy = await ethers.getContractFactory('Proxy');
+    const zkBNBProxy = await Proxy.deploy(zkBNBImpl.address, initParams);
+    await zkBNBProxy.deployed();
+    zkBNB = await ZkBNB.attach(zkBNBProxy.address);
   });
 
   it('create ZkBNBRelatedERC20', async function () {

--- a/test/nft/ZkBNB.nft.test.ts
+++ b/test/nft/ZkBNB.nft.test.ts
@@ -59,8 +59,8 @@ describe('NFT functionality', function () {
         Utils: utils.address,
       },
     });
-    zkBNB = await ZkBNBTest.deploy();
-    await zkBNB.deployed();
+    const zkBNBTestImpl = await ZkBNBTest.deploy();
+    await zkBNBTestImpl.deployed();
 
     const initParams = ethers.utils.defaultAbiCoder.encode(
       ['address', 'address', 'address', 'address', 'bytes32'],
@@ -72,7 +72,12 @@ describe('NFT functionality', function () {
         ethers.utils.formatBytes32String('genesisStateRoot'),
       ],
     );
-    await zkBNB.initialize(initParams);
+    await zkBNBTestImpl.initialize(initParams);
+
+    const Proxy = await ethers.getContractFactory('Proxy');
+    const zkBNBProxy = await Proxy.deploy(zkBNBTestImpl.address, initParams);
+    await zkBNBProxy.deployed();
+    zkBNB = await ZkBNBTest.attach(zkBNBProxy.address);
 
     const ZkBNBNFTFactory = await ethers.getContractFactory('ZkBNBNFTFactory');
     zkBNBNFTFactory = await ZkBNBNFTFactory.deploy('ZkBNBNft', 'Zk', zkBNB.address, owner.address);

--- a/test/zkBNB.deposit.test.js
+++ b/test/zkBNB.deposit.test.js
@@ -43,8 +43,8 @@ describe('ZkBNB', function () {
         Utils: utils.address,
       },
     });
-    zkBNB = await ZkBNB.deploy();
-    await zkBNB.deployed();
+    const zkBNBImpl = await ZkBNB.deploy();
+    await zkBNBImpl.deployed();
 
     const initParams = ethers.utils.defaultAbiCoder.encode(
       ['address', 'address', 'address', 'address', 'bytes32'],
@@ -56,7 +56,12 @@ describe('ZkBNB', function () {
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       ],
     );
-    await zkBNB.initialize(initParams);
+    await zkBNBImpl.initialize(initParams);
+
+    const Proxy = await ethers.getContractFactory('Proxy');
+    const zkBNBProxy = await Proxy.deploy(zkBNBImpl.address, initParams);
+    await zkBNBProxy.deployed();
+    zkBNB = await ZkBNB.attach(zkBNBProxy.address);
   });
 
   describe('Deposit', function () {


### PR DESCRIPTION
### Description

fix zkbnb protentially been selfdestruct

### Rationale

zkbnb implementation maybe selfdestruct by attacker

### Example

### Changes

Notable changes:
* add immutable variable `zkbnbImplementation` to ZkBNB.sol in constructor
* check `address(this) != zkbnbImplementation` when delegatecallAddtionalZkBNB
* change some testcase to fix conflicts