### PR TITLE
move verifyChangePubkey to TxTypes.sol

### DIFF
--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -359,7 +359,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
         TxTypes.ChangePubKey memory changePubKeyData = TxTypes.readChangePubKeyPubData(txPubData);
         bytes memory ethWitness = _newBlockData.onchainOperations[i].ethWitness;
         require(ethWitness.length != 0, "signature should not be empty");
-        bool valid = Utils.verifyChangePubkey(ethWitness, changePubKeyData);
+        bool valid = TxTypes.verifyChangePubkey(ethWitness, changePubKeyData);
         require(valid, "D"); // failed to verify change pubkey hash signature
       } else if (txType == TxTypes.TxType.Deposit) {
         bytes memory txPubData = Bytes.slice(pubData, pubdataOffset, TxTypes.PACKED_TX_PUBDATA_BYTES);

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -374,4 +374,33 @@ library TxTypes {
   function checkFullExitNftInPriorityQueue(FullExitNft memory _tx, bytes20 hashedPubData) internal pure returns (bool) {
     return Utils.hashBytesToBytes20(writeFullExitNftPubDataForPriorityQueue(_tx)) == hashedPubData;
   }
+
+  /// @notice Checks that signature is valid for pubkey change message
+  /// @param _ethWitness Version(1 byte) and signature (65 bytes)
+  /// @param _changePk Parsed change pubkey tx type
+  function verifyChangePubkey(bytes memory _ethWitness, ChangePubKey memory _changePk) external pure returns (bool) {
+    (, bytes memory signature) = Bytes.read(_ethWitness, 1, 65); // offset is 1 because we skip type of ChangePubkey
+
+    bytes32 messageHash = keccak256(
+      abi.encodePacked(
+        "\x19Ethereum Signed Message:\n265",
+        "Register zkBNB Account\n\n",
+        "pubkeyX: 0x",
+        Bytes.bytesToHexASCIIBytes(abi.encodePacked(_changePk.pubkeyX)),
+        "\n",
+        "pubkeyY: 0x",
+        Bytes.bytesToHexASCIIBytes(abi.encodePacked(_changePk.pubkeyY)),
+        "\n",
+        "nonce: 0x",
+        Bytes.bytesToHexASCIIBytes(Bytes.toBytesFromUInt32(_changePk.nonce)),
+        "\n",
+        "account index: 0x",
+        Bytes.bytesToHexASCIIBytes(Bytes.toBytesFromUInt32(_changePk.accountIndex)),
+        "\n\n",
+        "Only sign this message for a trusted client!"
+      )
+    );
+    address recoveredAddress = Utils.recoverAddressFromEthSignature(signature, messageHash);
+    return recoveredAddress == _changePk.owner;
+  }
 }

--- a/contracts/lib/Utils.sol
+++ b/contracts/lib/Utils.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "./Bytes.sol";
-import "./TxTypes.sol";
-import "../Storage.sol";
 
 library Utils {
   bytes constant SHA256_MULTI_HASH = hex"1220";
@@ -90,38 +85,6 @@ library Utils {
       pubData[i] = uint256(result) % q;
     }
     return pubData;
-  }
-
-  /// @notice Checks that signature is valid for pubkey change message
-  /// @param _ethWitness Version(1 byte) and signature (65 bytes)
-  /// @param _changePk Parsed change pubkey tx type
-  function verifyChangePubkey(
-    bytes memory _ethWitness,
-    TxTypes.ChangePubKey memory _changePk
-  ) external pure returns (bool) {
-    (, bytes memory signature) = Bytes.read(_ethWitness, 1, 65); // offset is 1 because we skip type of ChangePubkey
-
-    bytes32 messageHash = keccak256(
-      abi.encodePacked(
-        "\x19Ethereum Signed Message:\n265",
-        "Register zkBNB Account\n\n",
-        "pubkeyX: 0x",
-        Bytes.bytesToHexASCIIBytes(abi.encodePacked(_changePk.pubkeyX)),
-        "\n",
-        "pubkeyY: 0x",
-        Bytes.bytesToHexASCIIBytes(abi.encodePacked(_changePk.pubkeyY)),
-        "\n",
-        "nonce: 0x",
-        Bytes.bytesToHexASCIIBytes(Bytes.toBytesFromUInt32(_changePk.nonce)),
-        "\n",
-        "account index: 0x",
-        Bytes.bytesToHexASCIIBytes(Bytes.toBytesFromUInt32(_changePk.accountIndex)),
-        "\n\n",
-        "Only sign this message for a trusted client!"
-      )
-    );
-    address recoveredAddress = Utils.recoverAddressFromEthSignature(signature, messageHash);
-    return recoveredAddress == _changePk.owner;
   }
 
   /// @dev Converts hex string to base 58

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -199,6 +199,10 @@ async function main() {
 }
 
 async function getContractFactories() {
+  const TxTypes = await ethers.getContractFactory('TxTypes');
+  const txTypes = await TxTypes.deploy();
+  await txTypes.deployed();
+
   const Utils = await ethers.getContractFactory('Utils');
   const utils = await Utils.deploy();
   await utils.deployed();
@@ -215,7 +219,7 @@ async function getContractFactories() {
     Verifier: await ethers.getContractFactory('ZkBNBVerifier'),
     ZkBNB: await ethers.getContractFactory('ZkBNB', {
       libraries: {
-        Utils: utils.address,
+        TxTypes: txTypes.address,
       },
     }),
     DeployFactory: await ethers.getContractFactory('DeployFactory'),

--- a/test/DepolyFactory.test.ts
+++ b/test/DepolyFactory.test.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { smock } from '@defi-wonderland/smock';
+import { deployMockZkBNB } from './util';
 
 /* eslint-disable */
 const namehash = require('eth-ens-namehash');
@@ -9,7 +10,6 @@ chai.use(smock.matchers);
 
 describe('DeployFactory', function () {
   let DeployFactory;
-  let utils;
   let mockGovernanceTarget;
   let mockVerifierTarget;
   let mockZkbnbTarget;
@@ -29,20 +29,11 @@ describe('DeployFactory', function () {
   beforeEach(async function () {
     [owner, addr1, addr2, addr3, addr4] = await ethers.getSigners();
 
-    const Utils = await ethers.getContractFactory('Utils');
-    utils = await Utils.deploy();
-    await utils.deployed();
-
     DeployFactory = await ethers.getContractFactory('DeployFactory');
 
     mockGovernanceTarget = await smock.fake('Governance');
     mockVerifierTarget = await smock.fake('ZkBNBVerifier');
-    const ZkBNB = await ethers.getContractFactory('ZkBNB', {
-      libraries: {
-        Utils: utils.address,
-      },
-    });
-    mockZkbnbTarget = await smock.fake(ZkBNB);
+    mockZkbnbTarget = await deployMockZkBNB();
 
     mockValidator = addr1;
     mockGovernor = addr2;

--- a/test/ZkBNB.additional.test.ts
+++ b/test/ZkBNB.additional.test.ts
@@ -10,6 +10,8 @@ import {
   PubDataTypeMap,
   StoredBlockInfo,
   VerifyAndExecuteBlockInfo,
+  deployZkBNB,
+  deployZkBNBProxy,
   encodePackPubData,
   encodePubData,
   getChangePubkeyMessage,
@@ -43,8 +45,6 @@ describe('ZkBNB', function () {
     commitment,
   };
 
-  // `ZkBNB` needs to link to library `Utils` before deployed
-  let utils;
   const newStateRoot = ethers.utils.formatBytes32String('newStateRoot');
 
   // `beforeEach` will run before each test, re-deploying the contract every
@@ -59,21 +59,11 @@ describe('ZkBNB', function () {
 
     mockNftFactory = await smock.fake('ZkBNBNFTFactory');
 
-    const Utils = await ethers.getContractFactory('Utils');
-    utils = await Utils.deploy();
-    await utils.deployed();
-
     const AdditionalZkBNB = await ethers.getContractFactory('AdditionalZkBNBTest');
     additionalZkBNB = await AdditionalZkBNB.deploy(ethers.constants.AddressZero);
     await additionalZkBNB.deployed();
 
-    const ZkBNB = await ethers.getContractFactory('ZkBNBTest', {
-      libraries: {
-        Utils: utils.address,
-      },
-    });
-    const zkBNBTestImpl = await ZkBNB.deploy();
-    await zkBNBTestImpl.deployed();
+    const zkBNBTestImpl = await deployZkBNB('ZkBNBTest');
 
     const initParams = ethers.utils.defaultAbiCoder.encode(
       ['address', 'address', 'address', 'address', 'bytes32'],
@@ -87,10 +77,7 @@ describe('ZkBNB', function () {
     );
     await zkBNBTestImpl.initialize(initParams);
 
-    const Proxy = await ethers.getContractFactory('Proxy');
-    const zkBNBProxy = await Proxy.deploy(zkBNBTestImpl.address, initParams);
-    await zkBNBProxy.deployed();
-    zkBNB = await ZkBNB.attach(zkBNBProxy.address);
+    zkBNB = await deployZkBNBProxy(initParams, zkBNBTestImpl);
 
     // mock functions
     mockGovernance.getNFTFactory.returns(mockNftFactory.address);

--- a/test/upgradeable/UpgradeGatekeeper.test.js
+++ b/test/upgradeable/UpgradeGatekeeper.test.js
@@ -2,6 +2,8 @@ const chai = require('chai');
 const { ethers } = require('hardhat');
 const { smock } = require('@defi-wonderland/smock');
 
+const { deployMockZkBNB, deployMockGovernance } = require('../util');
+
 const { expect } = chai;
 chai.use(smock.matchers);
 
@@ -23,25 +25,13 @@ describe('UpgradeGatekeeper', function () {
   let mockUpgradeableMaster;
   let upgradeGatekeeper;
 
-  // `ZkBNB` needs to link to library `Utils` before deployed
-  let utils;
   let owner, addr1;
 
   before(async function () {
     [owner, addr1] = await ethers.getSigners();
 
     // 1. deploy logic contracts
-    const Utils = await ethers.getContractFactory('Utils');
-    utils = await Utils.deploy();
-    await utils.deployed();
-
-    const MockGovernance = await smock.mock('Governance', {
-      libraries: {
-        Utils: utils.address,
-      },
-    });
-    mockGovernance = await MockGovernance.deploy();
-    await mockGovernance.deployed();
+    mockGovernance = await deployMockGovernance();
 
     const MockZkBNBVerifier = await smock.mock('ZkBNBVerifier');
     mockZkBNBVerifier = await MockZkBNBVerifier.deploy();
@@ -55,15 +45,9 @@ describe('UpgradeGatekeeper', function () {
     mockPublicResolver = await MockPublicResolver.deploy();
     await mockPublicResolver.deployed();
 
-    const MockZkBNB = await smock.mock('ZkBNB', {
-      libraries: {
-        Utils: utils.address,
-      },
-    });
-    mockZkBNB = await MockZkBNB.deploy();
-    await mockZkBNB.deployed();
-    mockZkBNBNew = await MockZkBNB.deploy();
-    await mockZkBNBNew.deployed();
+    mockZkBNB = await deployMockZkBNB();
+    mockZkBNBNew = await deployMockZkBNB();
+
     newTargets = [
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,

--- a/test/upgradeable/UpgradeableMaster.test.js
+++ b/test/upgradeable/UpgradeableMaster.test.js
@@ -1,6 +1,7 @@
 const chai = require('chai');
 const { ethers, network } = require('hardhat');
 const { smock } = require('@defi-wonderland/smock');
+const { deployMockZkBNB } = require('../util');
 
 const { expect } = chai;
 chai.use(smock.matchers);
@@ -9,22 +10,13 @@ describe('UpgradeableMaster', function () {
   let mockZkBNB;
   let upgradeableMaster;
   let owner, councilMember1, councilMember2, councilMember3;
-  let utils;
   let UPGRADE_GATEKEEPER_ROLE;
   // `beforeEach` will run before each test, re-deploying the contract every
   // time. It receives a callback, which can be async.
   beforeEach(async function () {
     [owner, councilMember1, councilMember2, councilMember3] = await ethers.getSigners();
 
-    const Utils = await ethers.getContractFactory('Utils');
-    utils = await Utils.deploy();
-    await utils.deployed();
-    const MockZkBNB = await smock.mock('ZkBNB', {
-      libraries: {
-        Utils: utils.address,
-      },
-    });
-    mockZkBNB = await MockZkBNB.deploy();
+    mockZkBNB = await deployMockZkBNB();
     await mockZkBNB.deployed();
 
     const UpgradeableMaster = await ethers.getContractFactory('UpgradeableMaster');


### PR DESCRIPTION
### Description

Clean up unused imports and moved `verifyChangePubkey` to TxTypes.sol. Now `ZkBNB` contract has link to `TxTypes` lib instead of `Utils`.

### Changes

Notable changes:
*  moved`verifyChangePubkey` from `Utils.sol` to `TxTypes.sol`
*  updated `deploy.js`
*  refactor test cases to reuse code