### PR TITLE
fix: run times,verify and upgrade scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ BSC_TESTNET_RPC=https://data-seed-prebsc-2-s1.binance.org:8545
 BSC_TESTNET_PRIVATE_KEY=0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1
 BSC_MAINNET_RPC=https://bsc-dataseed.binance.org
 BSC_MAINNET_PRIVATE_KEY=0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1
-BSCSCAN_APIKEY=ABC123ABC123ABC123ABC123ABC123ABC1
+BSCSCAN_API_KEY=ABC123ABC123ABC123ABC123ABC123ABC1
 GNOSIS_SERVICE=https://safe-transaction-bsc.safe.global/
 
 # security Council Members for upgrade approve

--- a/contracts/test-contracts/AdditionalZkBNBTest.sol
+++ b/contracts/test-contracts/AdditionalZkBNBTest.sol
@@ -8,4 +8,7 @@ contract AdditionalZkBNBTest is AdditionalZkBNB {
   constructor(address _governanceAddress) {
     governance = Governance(_governanceAddress);
   }
+
+  // avoid same bytecode as AdditionalZkBNB
+  function nouse() external {}
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,7 +19,7 @@ const config: HardhatUserConfig = {
   etherscan: {
     // Your API key for BSC. Obtain one at https://bscscan.com/
     apiKey: {
-      bscTestnet: process.env.BSCSCAN_APIKEY || '00000000000000000000000000000000000000000',
+      bscTestnet: process.env.BSCSCAN_API_KEY || '00000000000000000000000000000000000000000',
       bsc: process.env.BSCSCAN_API_KEY || '00000000000000000000000000000000000000000',
     },
   },
@@ -28,7 +28,7 @@ const config: HardhatUserConfig = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 1500,
+        runs: 1000,
       },
       outputSelection: {
         '*': {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.1.4",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
-    "@openzeppelin/hardhat-upgrades": "^1.17.0",
+    "@openzeppelin/hardhat-upgrades": "^1.25.1",
     "@remix-project/remixd": "^0.6.0",
     "@typechain/ethers-v5": "^10.1.1",
     "@typechain/hardhat": "^6.1.4",

--- a/scripts/deploy-keccak256/deploy.js
+++ b/scripts/deploy-keccak256/deploy.js
@@ -86,7 +86,9 @@ async function main() {
     _genesisStateRoot,
     _listingFee,
     _listingCap,
-    { gasLimit: 13000000 },
+    {
+      gasLimit: 13000000,
+    },
   );
   await deployFactory.deployed();
 
@@ -111,7 +113,7 @@ async function main() {
     verifierEntryAddress,
     zkbnbEntryAddress,
     upgradeGatekeeperEntryAddress,
-    additionalZkBNBEntryAddress,
+    additionalZkBNBLogicAddress,
   ] = event;
 
   const assetGovernance = contractFactories.AssetGovernance.attach(assetGovernanceEntryAddress);
@@ -165,11 +167,12 @@ async function main() {
       verifierProxy: verifierEntryAddress,
       zkbnbProxy: zkbnbEntryAddress,
       upgradeGateKeeper: upgradeGatekeeperEntryAddress,
-      additionalZkBNB: additionalZkBNBEntryAddress,
+      additionalZkBNB: additionalZkBNBLogicAddress,
       ERC721: ERC721.address,
       DefaultNftFactory: DefaultNftFactory.address,
       upgradeableMaster: upgradeableMaster.address,
       utils: contractFactories.Utils.address,
+      txTypes: contractFactories.TxTypes.address,
       BUSDToken,
     }),
   );
@@ -188,16 +191,32 @@ async function main() {
       ],
     ],
     utils: [contractFactories.Utils.address],
+    txTypes: [contractFactories.TxTypes.address],
     verifierLogic: [verifier.address],
     zkbnbLogic: [zkbnb.address],
     upgradeGateKeeper: [upgradeGatekeeperEntryAddress, [upgradeableMaster.address]],
-    additionalZkBNB: [additionalZkBNBEntryAddress],
+    additionalZkBNB: [additionalZkBNBLogicAddress],
     ERC721: [ERC721.address, ['zkBNB', 'zkBNB', 0]],
     DefaultNftFactory: [DefaultNftFactory.address, ['zkBNB', 'zkBNB', zkbnbEntryAddress, governor]],
     upgradeableMaster: [upgradeableMaster.address, upgradeableMasterParams],
     governanceProxy: [governanceEntryAddress, [governance.address, abi.encode(['address'], [deployFactory.address])]],
-    verifierProxy: [verifierEntryAddress],
-    zkbnbProxy: [zkbnbEntryAddress],
+    verifierProxy: [verifierEntryAddress, [verifier.address, '0x']],
+    zkbnbProxy: [
+      zkbnbEntryAddress,
+      [
+        zkbnb.address,
+        abi.encode(
+          ['address', 'address', 'address', 'address', 'bytes32'],
+          [
+            governanceEntryAddress,
+            verifierEntryAddress,
+            additionalZkBNBLogicAddress,
+            desertVerifier.address,
+            _genesisStateRoot,
+          ],
+        ),
+      ],
+    ],
   });
 }
 
@@ -229,6 +248,7 @@ async function getContractFactories() {
     DefaultNftFactory: await ethers.getContractFactory('ZkBNBNFTFactory'),
     UpgradeableMaster: await ethers.getContractFactory('UpgradeableMaster'),
     Utils: utils,
+    TxTypes: txTypes,
   };
 }
 

--- a/scripts/upgrade/gnosis.js
+++ b/scripts/upgrade/gnosis.js
@@ -46,7 +46,7 @@ function main() {
         type: 'list',
         name: 'operator',
         message: 'What do you want?',
-        choices: ['start', 'preparation', 'cut period(only local)', 'cancel', 'finish', 'rollback'],
+        choices: ['start', 'preparation', 'cut period', 'cancel', 'finish', 'rollback'],
       },
     ])
     .then(async (answers) => {
@@ -129,15 +129,11 @@ async function start() {
         let deployContract, additionalZkBNB, desertVerifier;
         let Governance, ZkBNBVerifier, ZkBNB, AdditionalZkBNB;
 
-        const Utils = await ethers.getContractFactory('Utils');
-        const utils = await Utils.deploy();
-        await utils.deployed();
-
         switch (contract) {
           case 'governance':
             Governance = await ethers.getContractFactory('Governance', {
               libraries: {
-                Utils: utils.address,
+                Utils: addrs.utils,
               },
             });
             deployContract = await Governance.deploy();
@@ -149,7 +145,7 @@ async function start() {
           case 'zkbnb':
             ZkBNB = await ethers.getContractFactory('ZkBNB', {
               libraries: {
-                Utils: utils.address,
+                TxTypes: addrs.txTypes,
               },
             });
             deployContract = await ZkBNB.deploy();
@@ -257,37 +253,6 @@ async function cancel() {
 
 async function cutPeriod() {
   console.log(chalk.red('🚀 Please invoke contract function in BSCScan'));
-
-  // const securityCouncil1 = new ethers.Wallet(
-  //   '0x689af8efa8c651a91ad287602527f3af2fe9f6501a7ac4b061667b5a93e037fd',
-  //   ethers.provider,
-  // );
-  // const securityCouncil2 = new ethers.Wallet(
-  //   '0xde9be858da4a475276426320d5e9262ecfc3ba460bfac56360bfa6c4c28b4ee0',
-  //   ethers.provider,
-  // );
-  // const securityCouncil3 = new ethers.Wallet(
-  //   '0xdf57089febbacf7ba0bc227dafbffa9fc08a93fdc68e1e42411a14efcf23656e',
-  //   ethers.provider,
-  // );
-
-  // const addrs = getDeployedAddresses('info/addresses.json');
-
-  // const UpgradeableMaster = await ethers.getContractFactory('UpgradeableMaster');
-  // const upgradeableMaster = await UpgradeableMaster.attach(addrs.upgradeableMaster);
-  // console.log(chalk.green('🚀 Approve Upgrade'));
-  // await approve(securityCouncil1);
-  // await approve(securityCouncil2);
-  // await approve(securityCouncil3);
-  // console.log(chalk.green('✅ Approved'));
-  // async function approve(security) {
-  //   const tx = await upgradeableMaster.connect(security).cutUpgradeNoticePeriod();
-  //   const receipt = await tx.wait();
-  //   console.log(
-  //     'number Of approvals from security council %s',
-  //     receipt.events[0].args.numberOfApprovalsFromSecurityCouncil,
-  //   );
-  // }
 }
 
 async function finish() {

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -39,7 +39,6 @@ async function main() {
       console.log('❌[%s] %s\n %s', chalk.red(key), chalk.grey(`${bscscanURI}/${address}#code`), chalk.red(reason));
     }
   }
-  console.log('⚠️ %s', chalk.yellow('proxy need to verify manually'));
 }
 
 async function verifyContract(key, address, constructorArguments) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@aws-crypto/sha256-js@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz#02acd1a1fda92896fc5a28ec7c6e164644ea32fc"
+  integrity sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==
+  dependencies:
+    "@aws-crypto/util" "^1.2.2"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-1.2.2.tgz#b28f7897730eb6538b21c18bd4de22d0ea09003c"
+  integrity sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==
+  dependencies:
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/types@^3.1.0":
+  version "3.329.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.329.0.tgz#bc20659abfcd666954196c3a24ad47785db80dd3"
+  integrity sha512-wFBW4yciDfzQBSFmWNaEvHShnSGLMxSu9Lls6EUf6xDMavxSB36bsrVRX6CyAo/W0NeIIyEOW1LclGPgJV1okg==
+  dependencies:
+    tslib "^2.5.0"
+
+"@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.259.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz#3275a6f5eb334f96ca76635b961d3c50259fd9ff"
+  integrity sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==
+  dependencies:
+    tslib "^2.3.1"
+
 "@babel/code-frame@^7.0.0":
   version "7.21.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz"
@@ -1037,20 +1069,22 @@
   resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.2.tgz"
   integrity sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==
 
-"@openzeppelin/hardhat-upgrades@^1.17.0":
-  version "1.22.1"
-  resolved "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.22.1.tgz"
-  integrity sha512-MdoitCTLl4zwMU8MeE/bCj+7JMWBEvd38XqJkw36PkJrXlbv6FedDVCPoumMAhpmtymm0nTwTYYklYG+L6WiiQ==
+"@openzeppelin/hardhat-upgrades@^1.25.1":
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.25.1.tgz#e0a96f38a3948bb5b8db225bf0172e4b7e5de139"
+  integrity sha512-i9PGhyJRDALrvazNSsQWVUJkIwiZ9fMlidjwOEresBCzCdW8Npigoz4KSmfP78dgQ3kflDm/KWwCmyALnFgZNA==
   dependencies:
-    "@openzeppelin/upgrades-core" "^1.20.0"
+    "@openzeppelin/upgrades-core" "^1.26.0"
     chalk "^4.1.0"
     debug "^4.1.1"
+    defender-admin-client "^1.39.0"
+    platform-deploy-client "^0.3.2"
     proper-lockfile "^4.1.1"
 
-"@openzeppelin/upgrades-core@^1.20.0":
-  version "1.24.1"
-  resolved "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.24.1.tgz"
-  integrity sha512-QhdIQDUykJ3vQauB6CheV7vk4zgn0e1iY+IDg7r1KqpA1m2bqIGjQCpzidW33K4bZc9zdJSPx2/Z6Um5KxCB7A==
+"@openzeppelin/upgrades-core@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.26.0.tgz#809c276cb28540f8279604f169f685892f33f14f"
+  integrity sha512-iUrHdTvMxV4zWQ/baBTz3PMmnhoDyJ+TsnlH4/k15eutQi8G6YnS7ca8GAKm/9RFwHPeSjVcqPuWwa1QqL/1hw==
   dependencies:
     cbor "^8.0.0"
     chalk "^4.1.0"
@@ -1807,6 +1841,17 @@ ajv@^8.0.1, ajv@^8.11.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+amazon-cognito-identity-js@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.2.0.tgz#99e96666944429cb8f67b62e4cf7ad77fbe71ad0"
+  integrity sha512-9Fxrp9+MtLdsJvqOwSaE3ll+pneICeuE3pwj2yDkiyGNWuHx97b8bVLR2bOgfDmDJnY0Hq8QoeXtwdM4aaXJjg==
+  dependencies:
+    "@aws-crypto/sha256-js" "1.2.2"
+    buffer "4.9.2"
+    fast-base64-decode "^1.0.0"
+    isomorphic-unfetch "^3.0.0"
+    js-cookie "^2.2.1"
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
@@ -2109,6 +2154,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async-retry@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
+
 async@1.x, async@^1.4.2:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
@@ -2167,9 +2219,9 @@ axios@1.1.2:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^0.21.1:
+axios@^0.21.1, axios@^0.21.2:
   version "0.21.4"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
@@ -2720,7 +2772,7 @@ base-x@^3.0.2, base-x@^3.0.8:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -3040,6 +3092,15 @@ buffer-xor@^2.0.1:
   integrity sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==
   dependencies:
     safe-buffer "^5.1.1"
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 buffer@^5.0.5, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
   version "5.7.1"
@@ -3993,6 +4054,28 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
+
+defender-admin-client@^1.39.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/defender-admin-client/-/defender-admin-client-1.43.0.tgz#a04dd2c01c57599175efc754d0ff315564d6f7fd"
+  integrity sha512-EAB4dUkpcKjbLSHSTTw9KVmTrs8A36x+eVNt85Qr47ypilILtyNgjdqgvroda8syRicQBy28VBdUUWPJtVYAPA==
+  dependencies:
+    axios "^0.21.2"
+    defender-base-client "1.43.0"
+    ethers "^5.7.2"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
+
+defender-base-client@1.43.0, defender-base-client@^1.40.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/defender-base-client/-/defender-base-client-1.43.0.tgz#0b915ea9a1ac7f9ce67c381043aa4db035f43c5c"
+  integrity sha512-PFQPDZ08SznSlsKiHcvf1TzvKtnd/fv2/P5s2Y8jYPIb7OtANHw94oDFOOvRpg54o8EQItIb9v7H4g4kp/7fng==
+  dependencies:
+    amazon-cognito-identity-js "^6.0.1"
+    async-retry "^1.3.3"
+    axios "^0.21.2"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
 
 defer-to-connect@^1.0.1:
   version "1.1.3"
@@ -5303,6 +5386,11 @@ fake-merkle-patricia-tree@^1.0.1:
   dependencies:
     checkpoint-store "^1.1.0"
 
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
+
 fast-csv@^4.3.6:
   version "4.3.6"
   resolved "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz#70349bdd8fe4d66b1130d8c91820b64a21bc4a63"
@@ -6512,7 +6600,7 @@ idna-uts46-hx@^2.3.1:
   dependencies:
     punycode "2.1.0"
 
-ieee754@^1.1.13, ieee754@^1.2.1:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -7012,7 +7100,7 @@ isarray@0.0.1:
   resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
@@ -7041,10 +7129,23 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+isomorphic-unfetch@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
+  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
+  dependencies:
+    node-fetch "^2.6.1"
+    unfetch "^4.2.0"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
   integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-sdsl@^4.1.4:
   version "4.4.0"
@@ -8433,6 +8534,13 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@^2.6.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.9"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz"
@@ -9052,6 +9160,17 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
   integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
+
+platform-deploy-client@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/platform-deploy-client/-/platform-deploy-client-0.3.3.tgz#7358d3ee2747fdc8c094d8fed66929d8caeb09c7"
+  integrity sha512-CO7P0h8OHSa19QjA7hWbpmLPE0TPacDgdwA8Vwu9NnUdlYvXfF+q4f0FwaeS0vb1ruWtpkTfeIxy7Sc+TxgcNQ==
+  dependencies:
+    "@ethersproject/abi" "^5.6.3"
+    axios "^0.21.2"
+    defender-base-client "^1.40.0"
+    lodash "^4.17.19"
+    node-fetch "^2.6.0"
 
 pluralize@^8.0.0:
   version "8.0.0"
@@ -9777,6 +9896,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 retry@^0.12.0:
   version "0.12.0"
@@ -11018,12 +11142,12 @@ tslib@2.0.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.8.1, tslib@^1.9.3:
+tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
+tslib@^2.1.0, tslib@^2.3.1, tslib@^2.5.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
@@ -11266,6 +11390,11 @@ undici@^5.14.0:
   integrity sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==
   dependencies:
     busboy "^1.6.0"
+
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description

fix: optimizer run times, verify and upgrade scripts

### Rationale

- optimizer too big
- can not verify proxy
- upgrade script dependency library do not need re-deploy

### Example


### Changes

Notable changes:
* change optimizer run times to 1000
* upgrade @openzeppelin/hardhat-upgrades to latest version
* add nouse function in AdditionalZkBNBTest to avoid same bytecode as AdditionalZkBNB
* fix upgrade script to use right library address