### PR TITLE
Update Error code and remove unused imports

### DIFF
--- a/contracts/AdditionalZkBNB.sol
+++ b/contracts/AdditionalZkBNB.sol
@@ -6,12 +6,15 @@ import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "./lib/Utils.sol";
-import "./Storage.sol";
-import "./Config.sol";
+
 import "./interfaces/IEvents.sol";
+
+import "./lib/Utils.sol";
 import "./lib/Bytes.sol";
 import "./lib/TxTypes.sol";
+
+import "./Storage.sol";
+import "./Config.sol";
 import "./DesertVerifier.sol";
 
 /// @title ZkBNB additional main contract

--- a/contracts/AssetGovernance.sol
+++ b/contracts/AssetGovernance.sol
@@ -5,7 +5,6 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./Governance.sol";
-import "./lib/Utils.sol";
 
 /// @title Asset Governance Contract
 /// @author ZkBNB Team

--- a/contracts/DeployFactory.sol
+++ b/contracts/DeployFactory.sol
@@ -8,7 +8,6 @@ import "./UpgradeGatekeeper.sol";
 import "./UpgradeableMaster.sol";
 import "./ZkBNB.sol";
 import "./ZkBNBVerifier.sol";
-import "./Config.sol";
 
 contract DeployFactory {
   // This struct is used for avoiding StackTooDeep

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import "./Config.sol";
 import "./lib/Utils.sol";
 import "./lib/Bytes.sol";
+import "./Config.sol";
 import "./AssetGovernance.sol";
 import "./ZkBNBNFTFactory.sol";
 

--- a/contracts/Storage.sol
+++ b/contracts/Storage.sol
@@ -3,14 +3,12 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./interfaces/INFTFactory.sol";
+import "./lib/TxTypes.sol";
 
-import "./Config.sol";
 import "./Governance.sol";
 import "./ZkBNBVerifier.sol";
-import "./lib/TxTypes.sol";
 import "./AdditionalZkBNB.sol";
-import "./interfaces/INFTFactory.sol";
 import "./DesertVerifier.sol";
 
 /// @title zkbnb storage contract

--- a/contracts/UpgradeableMaster.sol
+++ b/contracts/UpgradeableMaster.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
-import "./Config.sol";
-import "./Storage.sol";
 import "./interfaces/IZkBNBDesertMode.sol";
 
 /// @title upgradeable master contract (defines notice period duration and allows finish upgrade during preparation of it)

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -3,17 +3,20 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import "./interfaces/IEvents.sol";
+import "./interfaces/INFTFactory.sol";
+
 import "./lib/Utils.sol";
 import "./lib/Bytes.sol";
 import "./lib/TxTypes.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "./interfaces/INFTFactory.sol";
+
 import "./Config.sol";
 import "./Storage.sol";
 import "./DesertVerifier.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title ZkBNB main contract
 /// @author ZkBNB Team

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -56,7 +56,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
   /// @dev _verifierAddress The address of Verifier contract
   /// @dev _genesisStateHash Genesis blocks (first block) state tree root hash
   function initialize(bytes calldata initializationParameters) external initializer {
-    require(address(this) != zkbnbImplementation, "Can not dirctly call by zkbnbImplementation");
+    require(address(this) != zkbnbImplementation, "1A");
 
     __ReentrancyGuard_init();
 
@@ -90,7 +90,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
   /// @param upgradeParameters Encoded representation of upgrade parameters
   // solhint-disable-next-line no-empty-blocks
   function upgrade(bytes calldata upgradeParameters) external nonReentrant {
-    require(address(this) != zkbnbImplementation, "Can not dirctly call by zkbnbImplementation");
+    require(address(this) != zkbnbImplementation, "2A");
 
     (address _additionalZkBNB, address _desertVerifier) = abi.decode(upgradeParameters, (address, address));
 
@@ -203,7 +203,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
     TxTypes.WithdrawNft memory op = pendingWithdrawnNFTs[_nftIndex];
     // _nftIndex needs to be valid , check op.nftContentHash in order to check op is not null
     require(op.nftContentHash != bytes32(0), "6H");
-    require(withdrawOrStoreNFT(op, WITHDRAWAL_PENDING_NFT_GAS_LIMIT), "Fail to withdraw NFT");
+    require(withdrawOrStoreNFT(op, WITHDRAWAL_PENDING_NFT_GAS_LIMIT), "3A");
     delete pendingWithdrawnNFTs[_nftIndex];
   }
 
@@ -362,7 +362,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
         bytes memory txPubData = Bytes.slice(pubData, pubdataOffset, TxTypes.PACKED_TX_PUBDATA_BYTES);
         TxTypes.ChangePubKey memory changePubKeyData = TxTypes.readChangePubKeyPubData(txPubData);
         bytes memory ethWitness = _newBlockData.onchainOperations[i].ethWitness;
-        require(ethWitness.length != 0, "signature should not be empty");
+        require(ethWitness.length != 0, "4A");
         bool valid = TxTypes.verifyChangePubkey(ethWitness, changePubKeyData);
         require(valid, "D"); // failed to verify change pubkey hash signature
       } else if (txType == TxTypes.TxType.Deposit) {
@@ -547,7 +547,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
   }
 
   function withdrawOrStoreNFT(TxTypes.WithdrawNft memory op, uint256 _gasLimit) internal returns (bool success) {
-    require(op.nftIndex <= MAX_NFT_INDEX, "invalid nft index");
+    require(op.nftIndex <= MAX_NFT_INDEX, "5A");
 
     // return success when withdrawPendingNFT
     success = false;
@@ -610,12 +610,9 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
 
       if (txType == TxTypes.TxType.Withdraw) {
         TxTypes.Withdraw memory _tx = TxTypes.readWithdrawPubData(pubData);
-        // Circuit guarantees that partial exits are available only for fungible tokens
-        //                require(_tx.assetId <= MAX_FUNGIBLE_ASSET_ID, "A");
         withdrawOrStore(uint16(_tx.assetId), _tx.toAddress, _tx.assetAmount);
       } else if (txType == TxTypes.TxType.FullExit) {
         TxTypes.FullExit memory _tx = TxTypes.readFullExitPubData(pubData);
-        //                require(_tx.assetId <= MAX_FUNGIBLE_ASSET_ID, "B");
         withdrawOrStore(uint16(_tx.assetId), _tx.owner, _tx.assetAmount);
       } else if (txType == TxTypes.TxType.FullExitNft) {
         TxTypes.FullExitNft memory _tx = TxTypes.readFullExitNftPubData(pubData);
@@ -693,7 +690,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
   /// @notice Should be only use to delegate the external calls as it passes the calldata
   /// @notice All functions delegated to additional contract should NOT be nonReentrant
   function delegateAdditional() internal {
-    require(address(this) != zkbnbImplementation, "Can not dirctly call by zkbnbImplementation");
+    require(address(this) != zkbnbImplementation, "6A");
     address _target = address(additionalZkBNB);
     assembly {
       // The pointer to the free memory slot

--- a/contracts/ZkBNBNFTFactory.sol
+++ b/contracts/ZkBNBNFTFactory.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./interfaces/INFTFactory.sol";
-import "./lib/Bytes.sol";
 import "./lib/Ownable2Step.sol";
 
 interface IZkBNB {

--- a/contracts/lib/Bytes.sol
+++ b/contracts/lib/Bytes.sol
@@ -158,8 +158,8 @@ library Bytes {
   // Returns the newly created 'bytes memory'
   // NOTE: theoretically possible overflow of (_start + _length)
   function slice(bytes memory _bytes, uint256 _start, uint256 _length) internal pure returns (bytes memory) {
-    require(_length + 31 >= _length, "slice_overflow");
-    require(_bytes.length >= _start + _length, "slice_outOfBounds");
+    require(_length + 31 >= _length, "1B");
+    require(_bytes.length >= _start + _length, "1S");
 
     bytes memory tempBytes;
 

--- a/test/ZkBNB.additional.test.ts
+++ b/test/ZkBNB.additional.test.ts
@@ -218,9 +218,7 @@ describe('ZkBNB', function () {
           blockSize: 2,
         };
         onchainOperations[0].ethWitness = '0x';
-        await expect(zkBNB.commitBlocks(genesisBlock, [commitBlock])).to.be.revertedWith(
-          'signature should not be empty',
-        );
+        await expect(zkBNB.commitBlocks(genesisBlock, [commitBlock])).to.be.revertedWith('4A');
         onchainOperations[0].ethWitness = ethers.utils.hexlify(ethers.utils.randomBytes(66));
         await expect(zkBNB.commitBlocks(genesisBlock, [commitBlock])).to.be.revertedWith('R');
         onchainOperations[0].ethWitness = ethWitness;

--- a/test/upgradeable/Proxy.test.js
+++ b/test/upgradeable/Proxy.test.js
@@ -199,7 +199,7 @@ describe('Proxy', function () {
         [attackerContract.address, mockDesertVerifier.address],
       );
 
-      await expect(zkBNB.upgrade(upgradeParams)).to.be.revertedWith('Can not dirctly call by zkbnbImplementation');
+      await expect(zkBNB.upgrade(upgradeParams)).to.be.revertedWith('2A');
       await proxy.upgradeTarget(zkBNB.address, upgradeParams);
     });
 
@@ -210,11 +210,11 @@ describe('Proxy', function () {
         [attackerContract.address, mockDesertVerifier.address],
       );
 
-      await expect(zkBNB.upgrade(upgradeParams)).to.be.revertedWith('Can not dirctly call by zkbnbImplementation');
+      await expect(zkBNB.upgrade(upgradeParams)).to.be.revertedWith('2A');
 
       mockGovernance.isActiveValidator.returns();
       // calls bypassing proxy contract should be intercepted
-      await expect(zkBNB.revertBlocks([])).to.be.revertedWith('Can not dirctly call by zkbnbImplementation');
+      await expect(zkBNB.revertBlocks([])).to.be.revertedWith('6A');
     });
 
     // await zkBNB.upgrade(upgradeParams) will fail

--- a/test/zkBNB.deposit.test.js
+++ b/test/zkBNB.deposit.test.js
@@ -44,12 +44,12 @@ describe('ZkBNB', function () {
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       ],
     );
-    await expect(zkBNBImpl.initialize(initParams)).to.be.revertedWith('Can not dirctly call by zkbnbImplementation');
+    await expect(zkBNBImpl.initialize(initParams)).to.be.revertedWith('1A');
     upgradeParams = ethers.utils.defaultAbiCoder.encode(
       ['address', 'address'],
       [additionalZkBNB.address, additionalZkBNB.address],
     );
-    await expect(zkBNBImpl.upgrade(upgradeParams)).to.be.revertedWith('Can not dirctly call by zkbnbImplementation');
+    await expect(zkBNBImpl.upgrade(upgradeParams)).to.be.revertedWith('2A');
 
     zkBNB = await deployZkBNBProxy(initParams, zkBNBImpl);
   });


### PR DESCRIPTION
### Description

Use error code instead of string on revert; removed unused imports; adjust the order of imports.

### Changes

Notable changes:
* updated revert errors and test cases
* removed `import "./Storage.sol";` from `UpgradeableMaster`
* removed `import "./lib/Utils.sol";` from `AssetGovernance`
* removed `import "./Config.sol";` from `UpgradeGatekeeper`
* removed `import "@openzeppelin/contracts/token/ERC20/IERC20.sol";` from `Storage`
* removed `import "./Config.sol";` from `Storage`
* removed `import "./Config.sol";` from `UpgradeableMaster`
* removed `import "./lib/Bytes.sol";` from `ZkBNBNFTFactory.sol`