### PR TITLE
feat: new desert verifier

### DIFF
--- a/contracts/AdditionalZkBNB.sol
+++ b/contracts/AdditionalZkBNB.sol
@@ -25,89 +25,129 @@ contract AdditionalZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable
     pendingBalances[_packedBalanceKey] = PendingBalance(balance + _amount, FILLED_GAS_RESERVE_VALUE);
   }
 
+  function createExitCommitment(uint256 stateRoot, bytes memory publicData) internal returns (bytes32) {
+    bytes32 converted = sha256(
+      abi.encodePacked(
+        stateRoot, // state root
+        publicData // pub data
+      )
+    );
+    return converted;
+  }
+
   /// @notice perform desert assets
   function performDesert(
     StoredBlockInfo memory _storedBlockInfo,
-    uint256 _nftRoot,
-    DesertVerifier.AssetExitData calldata _assetExitData,
-    DesertVerifier.AccountExitData calldata _accountExitData,
+    bytes memory _pubdata,
     uint256[] memory _proofs
   ) external nonReentrant {
-    require(_accountExitData.accountId <= MAX_ACCOUNT_INDEX, "e");
-    require(_accountExitData.accountId != SPECIAL_ACCOUNT_ID, "v");
-
     // must be in desert mode
     require(desertMode, "s");
     // already exited
-    require(!performedDesert[_accountExitData.accountId][_assetExitData.assetId], "t");
 
     // stored block info should be consistent
     require(storedBlockHashes[totalBlocksVerified] == hashStoredBlockInfo(_storedBlockInfo), "u");
+    require(_pubdata.length == TxTypes.PACKED_TX_PUBDATA_BYTES, "B");
 
-    bool proofCorrect = desertVerifier.verifyExitProofBalance(
-      uint256(stateRoot),
-      _nftRoot,
-      _assetExitData,
-      _accountExitData,
-      _proofs
-    );
+    // create commitment
+    bytes32 commitment = createExitCommitment(uint256(stateRoot), _pubdata);
+    uint256[1] memory inputs = [uint256(commitment)];
+
+    // verify proof
+    bool proofCorrect = desertVerifier.verifyProof(_proofs, inputs);
+
     require(proofCorrect, "x");
 
-    bytes22 packedBalanceKey = packAddressAndAssetId(_accountExitData.l1Address, _assetExitData.assetId);
-    increaseBalanceToWithdraw(packedBalanceKey, _assetExitData.amount);
-    emit WithdrawalPending(_assetExitData.assetId, _accountExitData.l1Address, _assetExitData.amount);
+    TxTypes.TxType txType = TxTypes.TxType(uint8(_pubdata[0]));
 
-    performedDesert[_accountExitData.accountId][_assetExitData.assetId] = true;
-  }
+    if (txType == TxTypes.TxType.FullExit) {
+      TxTypes.FullExit memory fullExitData = TxTypes.readFullExitPubData(_pubdata);
 
-  /// @notice perform desert nfts
-  function performDesertNft(
-    StoredBlockInfo memory _storedBlockInfo,
-    uint256 _assetRoot,
-    DesertVerifier.AccountExitData calldata _accountExitData,
-    DesertVerifier.NftExitData[] memory _exitNfts,
-    uint256[] memory _proofs
-  ) external nonReentrant {
-    require(_accountExitData.accountId <= MAX_ACCOUNT_INDEX, "e");
-    require(_accountExitData.accountId != SPECIAL_ACCOUNT_ID, "v");
-    require(_exitNfts.length >= 1, "Z");
+      require(!performedDesert[fullExitData.accountIndex][fullExitData.assetId], "t");
+      require(fullExitData.accountIndex <= MAX_ACCOUNT_INDEX, "e");
+      require(fullExitData.accountIndex != SPECIAL_ACCOUNT_ID, "v");
 
-    // must be in desert mode
-    require(desertMode, "s");
-    // stored block info should be consistent
-    require(storedBlockHashes[totalBlocksVerified] == hashStoredBlockInfo(_storedBlockInfo), "u");
+      bytes22 packedBalanceKey = packAddressAndAssetId(fullExitData.owner, fullExitData.assetId);
+      increaseBalanceToWithdraw(packedBalanceKey, fullExitData.assetAmount);
+      emit WithdrawalPending(fullExitData.assetId, fullExitData.owner, fullExitData.assetAmount);
 
-    bool proofCorrect = desertVerifier.verifyExitNftProof(
-      uint256(stateRoot),
-      _assetRoot,
-      _accountExitData,
-      _exitNfts,
-      _proofs
-    );
-    require(proofCorrect, "x");
+      performedDesert[fullExitData.accountIndex][fullExitData.assetId] = true;
+    } else if (txType == TxTypes.TxType.FullExitNft) {
+      TxTypes.FullExitNft memory fullExitNftData = TxTypes.readFullExitNftPubData(_pubdata);
 
-    for (uint256 i = 0; i < _exitNfts.length; ++i) {
-      DesertVerifier.NftExitData memory nft = _exitNfts[i];
-      // already exited
-      require(!performedDesertNfts[nft.nftIndex], "t");
+      require(fullExitNftData.accountIndex <= MAX_ACCOUNT_INDEX, "e");
+      require(fullExitNftData.accountIndex != SPECIAL_ACCOUNT_ID, "v");
+      require(!performedDesertNfts[fullExitNftData.nftIndex], "t");
 
-      TxTypes.WithdrawNft memory _withdrawNftTx = TxTypes.WithdrawNft({
-        accountIndex: _accountExitData.accountId,
-        creatorAccountIndex: nft.creatorAccountIndex,
-        creatorTreasuryRate: nft.creatorTreasuryRate,
-        nftIndex: nft.nftIndex,
-        collectionId: nft.collectionId,
-        toAddress: _accountExitData.l1Address,
-        creatorAddress: address(0),
-        nftContentHash: bytes32(bytes.concat(nft.nftContentHash1, nft.nftContentHash2)),
-        nftContentType: nft.nftContentType
+      TxTypes.WithdrawNft memory _withdrawNft = TxTypes.WithdrawNft({
+        accountIndex: fullExitNftData.accountIndex,
+        creatorAccountIndex: fullExitNftData.creatorAccountIndex,
+        creatorTreasuryRate: fullExitNftData.creatorTreasuryRate,
+        nftIndex: fullExitNftData.nftIndex,
+        collectionId: fullExitNftData.collectionId,
+        toAddress: fullExitNftData.owner,
+        creatorAddress: fullExitNftData.creatorAddress,
+        nftContentHash: fullExitNftData.nftContentHash,
+        nftContentType: fullExitNftData.nftContentType
       });
-      pendingWithdrawnNFTs[nft.nftIndex] = _withdrawNftTx;
-      emit WithdrawalNFTPending(nft.nftIndex);
+      pendingWithdrawnNFTs[fullExitNftData.nftIndex] = _withdrawNft;
+      emit WithdrawalNFTPending(fullExitNftData.nftIndex);
 
-      performedDesertNfts[nft.nftIndex] = true;
+      performedDesertNfts[fullExitNftData.nftIndex] = true;
+    } else {
+      // unsupported _tx
+      revert("F");
     }
   }
+
+  /* /// @notice perform desert nfts */
+  /* function performDesertNft( */
+  /*   StoredBlockInfo memory _storedBlockInfo, */
+  /*   uint256 _assetRoot, */
+  /*   DesertVerifier.AccountExitData calldata _accountExitData, */
+  /*   DesertVerifier.NftExitData[] memory _exitNfts, */
+  /*   uint256[] memory _proofs */
+  /* ) external nonReentrant { */
+  /*   require(_accountExitData.accountId <= MAX_ACCOUNT_INDEX, "e"); */
+  /*   require(_accountExitData.accountId != SPECIAL_ACCOUNT_ID, "v"); */
+  /*   require(_exitNfts.length >= 1, "Z"); */
+
+  /*   // must be in desert mode */
+  /*   require(desertMode, "s"); */
+  /*   // stored block info should be consistent */
+  /*   require(storedBlockHashes[totalBlocksVerified] == hashStoredBlockInfo(_storedBlockInfo), "u"); */
+
+  /*   bool proofCorrect = desertVerifier.verifyExitNftProof( */
+  /*     uint256(stateRoot), */
+  /*     _assetRoot, */
+  /*     _accountExitData, */
+  /*     _exitNfts, */
+  /*     _proofs */
+  /*   ); */
+  /*   require(proofCorrect, "x"); */
+
+  /*   for (uint256 i = 0; i < _exitNfts.length; ++i) { */
+  /*     DesertVerifier.NftExitData memory nft = _exitNfts[i]; */
+  /*     // already exited */
+  /*     require(!performedDesertNfts[nft.nftIndex], "t"); */
+
+  /*     TxTypes.WithdrawNft memory _withdrawNftTx = TxTypes.WithdrawNft({ */
+  /*       accountIndex: _accountExitData.accountId, */
+  /*       creatorAccountIndex: nft.creatorAccountIndex, */
+  /*       creatorTreasuryRate: nft.creatorTreasuryRate, */
+  /*       nftIndex: nft.nftIndex, */
+  /*       collectionId: nft.collectionId, */
+  /*       toAddress: _accountExitData.l1Address, */
+  /*       creatorAddress: address(0), */
+  /*       nftContentHash: bytes32(bytes.concat(nft.nftContentHash1, nft.nftContentHash2)), */
+  /*       nftContentType: nft.nftContentType */
+  /*     }); */
+  /*     pendingWithdrawnNFTs[nft.nftIndex] = _withdrawNftTx; */
+  /*     emit WithdrawalNFTPending(nft.nftIndex); */
+
+  /*     performedDesertNfts[nft.nftIndex] = true; */
+  /*   } */
+  /* } */
 
   /// @param _n Supposed number of requests to cancel (if there are fewer requests than the provided number - all of the requests will be canceled); but actual cancelled number could be smaller than _n because there could be `FullExit` request.
   /// @param _depositsPubData The array of the pubdata for the deposits to be cancelled.

--- a/contracts/AdditionalZkBNB.sol
+++ b/contracts/AdditionalZkBNB.sol
@@ -58,9 +58,9 @@ contract AdditionalZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable
 
     require(proofCorrect, "x");
 
-    TxTypes.TxType txType = TxTypes.TxType(uint8(_pubdata[0]));
+    DesertVerifier.DesertType exitType = DesertVerifier.DesertType(uint8(_pubdata[0]));
 
-    if (txType == TxTypes.TxType.FullExit) {
+    if (exitType == DesertVerifier.DesertType.ExitAsset) {
       TxTypes.FullExit memory fullExitData = TxTypes.readFullExitPubData(_pubdata);
 
       require(!performedDesert[fullExitData.accountIndex][fullExitData.assetId], "t");
@@ -72,7 +72,7 @@ contract AdditionalZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable
       emit WithdrawalPending(fullExitData.assetId, fullExitData.owner, fullExitData.assetAmount);
 
       performedDesert[fullExitData.accountIndex][fullExitData.assetId] = true;
-    } else if (txType == TxTypes.TxType.FullExitNft) {
+    } else if (exitType == DesertVerifier.DesertType.ExitNft) {
       TxTypes.FullExitNft memory fullExitNftData = TxTypes.readFullExitNftPubData(_pubdata);
 
       require(fullExitNftData.accountIndex <= MAX_ACCOUNT_INDEX, "e");

--- a/contracts/AdditionalZkBNB.sol
+++ b/contracts/AdditionalZkBNB.sol
@@ -51,7 +51,7 @@ contract AdditionalZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable
 
     // create commitment
     bytes32 commitment = createExitCommitment(uint256(stateRoot), _pubdata);
-    uint256[1] memory inputs = [uint256(commitment)];
+    uint256[1] memory inputs = [uint256(commitment) % desertVerifier.ScalarField()];
 
     // verify proof
     bool proofCorrect = desertVerifier.verifyProof(_proofs, inputs);
@@ -99,55 +99,6 @@ contract AdditionalZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable
       revert("F");
     }
   }
-
-  /* /// @notice perform desert nfts */
-  /* function performDesertNft( */
-  /*   StoredBlockInfo memory _storedBlockInfo, */
-  /*   uint256 _assetRoot, */
-  /*   DesertVerifier.AccountExitData calldata _accountExitData, */
-  /*   DesertVerifier.NftExitData[] memory _exitNfts, */
-  /*   uint256[] memory _proofs */
-  /* ) external nonReentrant { */
-  /*   require(_accountExitData.accountId <= MAX_ACCOUNT_INDEX, "e"); */
-  /*   require(_accountExitData.accountId != SPECIAL_ACCOUNT_ID, "v"); */
-  /*   require(_exitNfts.length >= 1, "Z"); */
-
-  /*   // must be in desert mode */
-  /*   require(desertMode, "s"); */
-  /*   // stored block info should be consistent */
-  /*   require(storedBlockHashes[totalBlocksVerified] == hashStoredBlockInfo(_storedBlockInfo), "u"); */
-
-  /*   bool proofCorrect = desertVerifier.verifyExitNftProof( */
-  /*     uint256(stateRoot), */
-  /*     _assetRoot, */
-  /*     _accountExitData, */
-  /*     _exitNfts, */
-  /*     _proofs */
-  /*   ); */
-  /*   require(proofCorrect, "x"); */
-
-  /*   for (uint256 i = 0; i < _exitNfts.length; ++i) { */
-  /*     DesertVerifier.NftExitData memory nft = _exitNfts[i]; */
-  /*     // already exited */
-  /*     require(!performedDesertNfts[nft.nftIndex], "t"); */
-
-  /*     TxTypes.WithdrawNft memory _withdrawNftTx = TxTypes.WithdrawNft({ */
-  /*       accountIndex: _accountExitData.accountId, */
-  /*       creatorAccountIndex: nft.creatorAccountIndex, */
-  /*       creatorTreasuryRate: nft.creatorTreasuryRate, */
-  /*       nftIndex: nft.nftIndex, */
-  /*       collectionId: nft.collectionId, */
-  /*       toAddress: _accountExitData.l1Address, */
-  /*       creatorAddress: address(0), */
-  /*       nftContentHash: bytes32(bytes.concat(nft.nftContentHash1, nft.nftContentHash2)), */
-  /*       nftContentType: nft.nftContentType */
-  /*     }); */
-  /*     pendingWithdrawnNFTs[nft.nftIndex] = _withdrawNftTx; */
-  /*     emit WithdrawalNFTPending(nft.nftIndex); */
-
-  /*     performedDesertNfts[nft.nftIndex] = true; */
-  /*   } */
-  /* } */
 
   /// @param _n Supposed number of requests to cancel (if there are fewer requests than the provided number - all of the requests will be canceled); but actual cancelled number could be smaller than _n because there could be `FullExit` request.
   /// @param _depositsPubData The array of the pubdata for the deposits to be cancelled.

--- a/contracts/DesertVerifier.sol
+++ b/contracts/DesertVerifier.sol
@@ -1,54 +1,128 @@
 // SPDX-License-Identifier: Apache-2.0
+
 pragma solidity ^0.8.0;
 
 contract DesertVerifier {
-  struct AssetExitData {
-    uint16 assetId;
-    uint128 amount;
-    uint offerCanceledOrFinalized;
+  function initialize(bytes calldata) external {}
+
+  /// @notice Verifier contract upgrade. Can be external because Proxy contract intercepts illegal calls of this function.
+  /// @param upgradeParameters Encoded representation of upgrade parameters
+  function upgrade(bytes calldata upgradeParameters) external {}
+
+  function ScalarField() public pure returns (uint256) {
+    return 21888242871839275222246405745257275088548364400416034343698204186575808495617;
   }
 
-  struct AccountExitData {
-    uint32 accountId;
-    address l1Address;
-    bytes32 pubKeyX;
-    bytes32 pubKeyY;
-    uint nonce;
-    uint collectionNonce;
+  function NegateY(uint256 Y) internal pure returns (uint256) {
+    uint256 q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+    return q - (Y % q);
   }
 
-  struct NftExitData {
-    uint40 nftIndex;
-    uint ownerAccountIndex;
-    uint32 creatorAccountIndex;
-    uint16 creatorTreasuryRate;
-    uint16 collectionId;
-    bytes16 nftContentHash1;
-    bytes16 nftContentHash2;
-    uint8 nftContentType;
+  function verifyingKey() internal pure returns (uint256[14] memory vk) {
+    vk[0] = 4332282361164897797675311661395815642917995109191125877639027900642369905087;
+    vk[1] = 12915330585801744505995416820486647993126118116183412393542485676988967451091;
+    vk[2] = 17860995496969555127674265474234450104887710110914926552181198899561228684333;
+    vk[3] = 4566870234630447608229406053961781787611601928754981586980030719858216206233;
+    vk[4] = 18537902144770205516281248737600399019882402187770060650423584032982915386893;
+    vk[5] = 8540160583538870870639361602464065058255039296984079782431552614735552650759;
+    vk[6] = 13807336353012580443260123717250702852931145724512070154267416753284007420931;
+    vk[7] = 4800490065510923949887014006966892108325330496229982991949524650123880696923;
+    vk[8] = 7505803066983338220061834147579084920764207912063867422074941187055377844616;
+    vk[9] = 11646201873558741118621284933802498820762140029847474502612660658348362883753;
+    vk[10] = 8859981885045358148321205927115930930337546008236789731792835411701566770923;
+    vk[11] = 5399739975945993060216793074570285914060274546645684893364780254319516591516;
+    vk[12] = 16820147133744285682491834542510503041176406171597133126836277331647814160010;
+    vk[13] = 14326571654886908959410100255674142006394529598302641673796312373415903048453;
+    return vk;
   }
 
-  /// @notice verify ownership of assets
-  function verifyExitProofBalance(
-    uint256 stateRoot,
-    uint256 nftRoot,
-    AssetExitData calldata assetData,
-    AccountExitData calldata accountData,
-    uint256[] memory _proofs
-  ) external view returns (bool) {
-    // TODO
-    return false;
+  function ic() internal pure returns (uint256[] memory gammaABC) {
+    gammaABC = new uint256[](4);
+    gammaABC[0] = 14649434776748726606114824897549043725345223405947397984566216138147924313946;
+    gammaABC[1] = 15694799062460067161648900813794732494784648227126097736137536777281811878724;
+    gammaABC[2] = 19562290364503525143391379247361981963058811504784444565069628412576734898396;
+    gammaABC[3] = 10486766752947749952521960315870987175617388599899416827646878013322810980893;
+    return gammaABC;
   }
 
-  /// @notice verify ownership of nfts
-  function verifyExitNftProof(
-    uint256 stateRoot,
-    uint256 assetRoot,
-    AccountExitData memory accountData,
-    NftExitData[] memory exitNfts,
-    uint256[] memory _proofs
+  // original equation
+  // e(proof.A, proof.B)*e(-vk.alpha, vk.beta)*e(-vk_x, vk.gamma)*e(-proof.C, vk.delta) == 1
+  function verifyProof(
+    uint256[] memory in_proof, // proof itself, length is 8 * num_proofs
+    uint256[1] memory proof_inputs // public inputs, length is num_inputs * num_proofs
   ) public view returns (bool) {
-    // TODO
-    return false;
+    uint256[14] memory in_vk = verifyingKey();
+    uint256[] memory vk_gammaABC = ic();
+    require(((vk_gammaABC.length / 2) - 1) == proof_inputs.length);
+    require(in_proof.length == 8);
+    // Compute the linear combination vk_x
+    uint256[3] memory mul_input;
+    uint256[4] memory add_input;
+    bool success;
+    uint256 m = 2;
+
+    // First two fields are used as the sum
+    add_input[0] = vk_gammaABC[0];
+    add_input[1] = vk_gammaABC[1];
+
+    // uint256 q = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    // Performs a sum of gammaABC[0] + sum[ gammaABC[i+1]^proof_inputs[i] ]
+    for (uint256 i = 0; i < proof_inputs.length; ++i) {
+      // @dev only for qa test
+      //  require(proof_inputs[i] < q, "INVALID_INPUT");
+      mul_input[0] = vk_gammaABC[m++];
+      mul_input[1] = vk_gammaABC[m++];
+      mul_input[2] = proof_inputs[i];
+
+      assembly {
+        // ECMUL, output to last 2 elements of `add_input`
+        success := staticcall(sub(gas(), 2000), 7, mul_input, 0x80, add(add_input, 0x40), 0x60)
+      }
+      require(success);
+
+      assembly {
+        // ECADD
+        success := staticcall(sub(gas(), 2000), 6, add_input, 0xc0, add_input, 0x60)
+      }
+      require(success);
+    }
+
+    uint256[24] memory input = [
+      // (proof.A, proof.B)
+      in_proof[0],
+      in_proof[1], // proof.A   (G1)
+      in_proof[2],
+      in_proof[3],
+      in_proof[4],
+      in_proof[5], // proof.B   (G2)
+      // (-vk.alpha, vk.beta)
+      in_vk[0],
+      NegateY(in_vk[1]), // -vk.alpha (G1)
+      in_vk[2],
+      in_vk[3],
+      in_vk[4],
+      in_vk[5], // vk.beta   (G2)
+      // (-vk_x, vk.gamma)
+      add_input[0],
+      NegateY(add_input[1]), // -vk_x     (G1)
+      in_vk[6],
+      in_vk[7],
+      in_vk[8],
+      in_vk[9], // vk.gamma  (G2)
+      // (-proof.C, vk.delta)
+      in_proof[6],
+      NegateY(in_proof[7]), // -proof.C  (G1)
+      in_vk[10],
+      in_vk[11],
+      in_vk[12],
+      in_vk[13] // vk.delta  (G2)
+    ];
+
+    uint256[1] memory out;
+    assembly {
+      success := staticcall(sub(gas(), 2000), 8, input, 768, out, 0x20)
+    }
+    require(success);
+    return out[0] == 1;
   }
 }

--- a/contracts/DesertVerifier.sol
+++ b/contracts/DesertVerifier.sol
@@ -3,6 +3,12 @@
 pragma solidity ^0.8.0;
 
 contract DesertVerifier {
+  enum DesertType {
+    Noop,
+    ExitAsset,
+    ExitNft
+  }
+
   function initialize(bytes calldata) external {}
 
   /// @notice Verifier contract upgrade. Can be external because Proxy contract intercepts illegal calls of this function.

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -142,20 +142,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
 
   function performDesert(
     StoredBlockInfo memory _storedBlockInfo,
-    uint256 _nftRoot,
-    DesertVerifier.AssetExitData calldata _assetExitData,
-    DesertVerifier.AccountExitData calldata _accountExitData,
-    uint256[] memory _proofs
-  ) external {
-    /// All functions delegated to additional should NOT be nonReentrant
-    delegateAdditional();
-  }
-
-  function performDesertNft(
-    StoredBlockInfo memory _storedBlockInfo,
-    uint256 _assetRoot,
-    DesertVerifier.AccountExitData calldata _accountExitData,
-    DesertVerifier.NftExitData[] memory _exitNfts,
+    bytes memory _pubdata,
     uint256[] memory _proofs
   ) external {
     /// All functions delegated to additional should NOT be nonReentrant

--- a/contracts/lib/TxTypes.sol
+++ b/contracts/lib/TxTypes.sol
@@ -81,7 +81,7 @@ library TxTypes {
     uint16 creatorTreasuryRate;
     uint40 nftIndex;
     uint16 collectionId;
-    address owner; // accountNameHahsh => owner
+    address owner; // l1Address
     address creatorAddress; // creatorAccountNameHash => creatorAddress
     bytes32 nftContentHash;
     uint8 nftContentType; // New added
@@ -93,7 +93,7 @@ library TxTypes {
     uint16 creatorTreasuryRate;
     uint40 nftIndex;
     uint16 collectionId;
-    address owner; // accountNameHahsh => owner
+    address owner; // l1Address
     bytes32 nftContentHash;
     uint8 nftContentType; // New added
   }


### PR DESCRIPTION
### Description

Use groth16 to verify desert exit proof. `FullExit` and `FullExitNft` pubdata are reused for ser/deserd fields required to do asset/nft withdrawls.

### Rationale
Compared with merkle proof, groth16 is 
1. more gas-saving 
2. independant of Layer2 smt structure

### Changes

Notable changes:
* added `DesertVerifier.sol`
* combined `performDesert` and `performDesertNft` into `performDesert`
* add function `createExitCommitment`