### PR TITLE
fix: add `_disableInitializers()` to ZkBNB and Governance constructor

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -70,7 +70,18 @@ contract Governance is Config, Initializable, ReentrancyGuardUpgradeable {
   /// @notice ZkBNB address has set
   event SetZkBNB(address indexed zkBNBAddress);
 
-  /// @notice Governance contract initialization. Can be external because Proxy contract intercepts illegal calls of this function.
+  // OpenZeppelin Contracts (last updated v4.9.0) (proxy/utils/Initializable.sol)
+  // * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure */
+  // * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity. */
+  // * Avoid leaving a contract uninitialized. */
+  // * An uninitialized contract can be taken over by an attacker. This applies to both a proxy and its implementation */
+  // * contract, which may impact the proxy. To prevent the implementation contract from being used, you should invoke */
+  // * the {_disableInitializers} function in the constructor to automatically lock it when it is deployed: */
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @notice Governance contract initialization.
   /// @param initializationParameters Encoded representation of initialization parameters:
   ///     _networkGovernor The address of network governor
   function initialize(bytes calldata initializationParameters) external initializer {

--- a/contracts/UpgradeGatekeeper.sol
+++ b/contracts/UpgradeGatekeeper.sol
@@ -126,7 +126,7 @@ contract UpgradeGatekeeper is IUpgradeEvents, ZkBNBOwnable {
       }
     }
     ++versionId;
-    emit UpgradeComplete(versionId, nextTargets);
+    emit UpgradeComplete(versionId, nextTargets, targetsUpgradeParameters);
 
     upgradeStatus = UpgradeStatus.Idle;
     noticePeriodFinishTimestamp = 0;

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -49,8 +49,16 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
 
   address private immutable zkbnbImplementation;
 
+  // OpenZeppelin Contracts (last updated v4.9.0) (proxy/utils/Initializable.sol)
+  // * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure */
+  // * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity. */
+  // * Avoid leaving a contract uninitialized. */
+  // * An uninitialized contract can be taken over by an attacker. This applies to both a proxy and its implementation */
+  // * contract, which may impact the proxy. To prevent the implementation contract from being used, you should invoke */
+  // * the {_disableInitializers} function in the constructor to automatically lock it when it is deployed: */
   constructor() {
     zkbnbImplementation = address(this);
+    _disableInitializers();
   }
 
   /// @notice ZkBNB contract initialization.
@@ -290,9 +298,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
 
     // Check timestamp of the new block
     // Block should be after previous block
-    {
-      require(_newBlock.timestamp >= _previousBlock.timestamp, "g");
-    }
+    require(_newBlock.timestamp >= _previousBlock.timestamp, "g");
 
     // Check onchain operations
     (bytes32 pendingOnchainOpsHash, uint64 priorityReqCommitted) = collectOnchainOps(_newBlock);

--- a/contracts/ZkBNB.sol
+++ b/contracts/ZkBNB.sol
@@ -213,6 +213,7 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
     uint128 amount = Utils.minU128(balance, _amount);
     require(amount > 0, "f1"); // Nothing to withdraw
 
+    pendingBalances[packedBalanceKey].balanceToWithdraw = balance - amount;
     if (_assetId == 0) {
       (bool success, ) = _owner.call{value: amount}("");
       // Native Asset withdraw failed
@@ -223,7 +224,6 @@ contract ZkBNB is IEvents, Storage, Config, ReentrancyGuardUpgradeable, IERC721R
       // `value` can be bigger then `_amount` requested if token takes fee from sender in addition to `_amount` requested
       amount = this.transferERC20(IERC20(_token), _owner, amount, balance);
     }
-    pendingBalances[packedBalanceKey].balanceToWithdraw = balance - amount;
     emit Withdrawal(_assetId, amount);
   }
 

--- a/contracts/interfaces/IEvents.sol
+++ b/contracts/interfaces/IEvents.sol
@@ -102,5 +102,5 @@ interface IUpgradeEvents {
   event PreparationStart(uint256 indexed versionId);
 
   /// @notice Upgrade mode complete event
-  event UpgradeComplete(uint256 indexed versionId, address[] newTargets);
+  event UpgradeComplete(uint256 indexed versionId, address[] newTargets, bytes[] targetsUpgradeParameters);
 }

--- a/test/upgradeable/UpgradeGatekeeper.test.js
+++ b/test/upgradeable/UpgradeGatekeeper.test.js
@@ -182,7 +182,7 @@ describe('UpgradeGatekeeper', function () {
 
       await expect(upgradeGatekeeper.finishUpgrade(mockParamters))
         .to.emit(upgradeGatekeeper, 'UpgradeComplete')
-        .withArgs(1, newTargets);
+        .withArgs(1, newTargets, mockParamters);
 
       // Check states are cleared
       // versionId == 1

--- a/test/util.ts
+++ b/test/util.ts
@@ -254,3 +254,23 @@ export async function deployZkBNBProxy(initParams: string, implContract: Contrac
 
   return zkBNB;
 }
+
+export async function deployGovernanceProxy(initParams: string, implContract: Contract) {
+  const Utils = await ethers.getContractFactory('Utils');
+  const utils = await Utils.deploy();
+  await utils.deployed();
+
+  const Governance = await ethers.getContractFactory('Governance', {
+    libraries: {
+      Utils: utils.address,
+    },
+  });
+  const Proxy = await ethers.getContractFactory('Proxy');
+
+  const governanceProxy = await Proxy.deploy(implContract.address, initParams);
+  await governanceProxy.deployed();
+
+  const governance = Governance.attach(governanceProxy.address);
+
+  return governance;
+}

--- a/test/zkBNB.deposit.test.js
+++ b/test/zkBNB.deposit.test.js
@@ -44,7 +44,7 @@ describe('ZkBNB', function () {
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       ],
     );
-    await expect(zkBNBImpl.initialize(initParams)).to.be.revertedWith('1A');
+    await expect(zkBNBImpl.initialize(initParams)).to.be.revertedWith('Initializable: contract is already initialized');
     upgradeParams = ethers.utils.defaultAbiCoder.encode(
       ['address', 'address'],
       [additionalZkBNB.address, additionalZkBNB.address],


### PR DESCRIPTION
### Description

According to [OpenZepplin docs](https://docs.openzeppelin.com/contracts/4.x/api/proxy#Initializable-_disableInitializers--), it is recommended to use `_disableInitializers ` to lock implementation contracts that are designed to be called through proxies.

>Avoid leaving a contract uninitialized.
An uninitialized contract can be taken over by an attacker. This applies to both a proxy and its implementation contract, which may impact the proxy. To prevent the implementation contract from being used, you should invoke the [_disableInitializers](https://docs.openzeppelin.com/contracts/4.x/api/proxy#Initializable-_disableInitializers--) function in the constructor to automatically lock it when it is deployed:

### Changes

Notable changes:
* added `_disableInitializers` to ZkBNB and Governance constructors
* emit `targetsUpgradeParameters` in `UpgradeComplete` event in case of rollback
* follow Checks Effects Interactions pattern in `withdrawPendingBalance`